### PR TITLE
Add GitHub Actions workflow to deploy portfolio to GitHub Pages (Node 24)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,53 @@
+name: Deploy portfolio to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./build
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
### Motivation
- Ensure the portfolio is built and deployed via GitHub Actions using a modern Node runtime (Node 24) to avoid Node version warnings during deploy and to provide a reproducible build pipeline.
- Provide a dedicated Pages deployment workflow so GitHub Pages can be driven by Actions and the artifact upload/deploy steps are explicit.
- Configure required Pages permissions and an explicit deployment environment to match GitHub Pages requirements.

### Description
- Added `.github/workflows/pages.yml` which checks out the repo, sets up Node 24 using `actions/setup-node@v6`, installs dependencies with `npm ci`, runs the build with `npm run build`, uploads `./build` via `actions/upload-pages-artifact@v3`, and deploys with `actions/deploy-pages@v4`.
- The workflow grants `contents: read`, `pages: write`, and `id-token: write` permissions and defines a concurrency group named `pages` to coordinate deployments.
- The workflow triggers on pushes to `main` and on manual `workflow_dispatch` runs.
- The new workflow file was added and committed to the repository.

### Testing
- The workflow file was created and committed successfully as `.github/workflows/pages.yml` (commit recorded).
- Running `npm ci` locally failed with a `403 Forbidden` from the registry for `express-4.21.1.tgz`, so dependency installation could not complete.
- Running `npm run build` locally failed because `react-scripts` was not available in the local `node_modules`, so a local build could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4792d4419c832cb18ebd0891ffb54c)