### PR TITLE
Fix GitHub Pages section navigation

### DIFF
--- a/src/components/NavLinks/NavLinks.jsx
+++ b/src/components/NavLinks/NavLinks.jsx
@@ -2,13 +2,17 @@ import React from 'react';
 import { NavLink } from 'react-router-dom';
 import { Nav } from './NavStyles';
 
+const getSectionHref = (sectionId) => `${process.env.PUBLIC_URL || ''}/#${sectionId}`;
+
 const NavLinks = () => (
   <Nav aria-label="Navigation principale">
     <ul>
       <li><NavLink to="/">Portfolio</NavLink></li>
-      <li><a href="/#projets">Projets</a></li>
-      <li><a href="/#parcours">Parcours</a></li>
+      <li><a href={getSectionHref('projets')}>Projets</a></li>
+      <li><a href={getSectionHref('competences')}>Compétences</a></li>
+      <li><a href={getSectionHref('parcours')}>Parcours</a></li>
       <li><NavLink to="/cv">CV</NavLink></li>
+      <li><a href={getSectionHref('contact')}>Contact</a></li>
     </ul>
   </Nav>
 );

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -49,12 +49,12 @@ const Home = () => {
         <FeaturedGrid>{featuredProjects.map((project) => <Card key={project.id} project={project} onClickMoreInfo={setSelectedCardId} />)}</FeaturedGrid>
       </Section>
 
-      <Section>
+      <Section id="atelier">
         <SectionHeader><div><Eyebrow>Atelier</Eyebrow><h2>Ce que je construis</h2></div><p>Des livrables compréhensibles, documentés et reliés à un usage métier.</p></SectionHeader>
         <CapabilityGrid>{capabilities.map((capability) => <CapabilityCard key={capability.title}><h3>{capability.title}</h3><p>{capability.text}</p></CapabilityCard>)}</CapabilityGrid>
       </Section>
 
-      <Section>
+      <Section id="case-studies">
         <SectionHeader><div><Eyebrow>Narration</Eyebrow><h2>Case studies</h2></div><p>Un format court pour comprendre le problème, la solution et la valeur de chaque projet principal.</p></SectionHeader>
         {caseStudies.map((project) => (
           <CaseStudy key={project.id} $accent={project.accent}>
@@ -64,7 +64,7 @@ const Home = () => {
         ))}
       </Section>
 
-      <Section>
+      <Section id="catalogue">
         <SectionHeader><div><Eyebrow>Catalogue</Eyebrow><h2>Tous les projets</h2></div><p>Les archives restent présentes, mais ne dominent plus la lecture du parcours.</p></SectionHeader>
         <FilterBar aria-label="Filtrer les projets par catégorie">
           {projectCategories.map((category) => <FilterButton key={category.id} type="button" $active={activeCategory === category.id} onClick={() => setActiveCategory(category.id)}>{category.label}</FilterButton>)}
@@ -72,7 +72,7 @@ const Home = () => {
         <ContainerProject>{filteredProjects.map((project) => <Card key={project.id} project={project} onClickMoreInfo={setSelectedCardId} />)}</ContainerProject>
       </Section>
 
-      <Section>
+      <Section id="competences">
         <SectionHeader><div><Eyebrow>Stack</Eyebrow><h2>Compétences</h2></div><p>Une base web solide, renforcée par Java/Spring, Angular et une montée en puissance data / BI.</p></SectionHeader>
         <SkillsGrid>{skills.map((skill) => <SkillCard key={skill.group}><h3>{skill.group}</h3><ul>{skill.items.map((item) => <li key={item}>{item}</li>)}</ul></SkillCard>)}</SkillsGrid>
       </Section>


### PR DESCRIPTION
### Motivation
- Ensure header section anchors keep the site under the GitHub Pages subpath (`/portfolio/`) by using the app `PUBLIC_URL` when generating fragment links.
- Preserve client-side routing for page navigation (keep `NavLink` for route-level links) while fixing intra-page anchors that were pointing to the site root.
- Add missing section `id` attributes on the home page so header anchors have real targets to scroll to.

### Description
- Add `getSectionHref(sectionId)` to `src/components/NavLinks/NavLinks.jsx` which returns ```${process.env.PUBLIC_URL || ''}/#${sectionId}``` and use it for header anchors.
- Replace absolute anchors in the header with `getSectionHref(...)` for `projets`, `competences`, `parcours` and `contact`, while keeping `NavLink` for `Portfolio` (`/`) and `CV` (`/cv`).
- Add the missing `id` attributes in `src/pages/Home/Home.jsx` on the `Section` elements: `id="atelier"`, `id="case-studies"`, `id="catalogue"` and `id="competences"`, leaving existing `id`s `projets`, `parcours` and `contact` untouched.

### Testing
- Ran a pattern search with `rg` to confirm `getSectionHref` usage and the expected `id` attributes and it succeeded.
- Ran `git diff --check` to validate no whitespace or basic diff issues and it succeeded.
- Ran `npm ci` which failed due to a registry error (`403 Forbidden` when fetching `express-4.21.1.tgz`), so dependencies were not installed.
- Ran `npm run build` which could not run because `react-scripts` was not available after the failed install, so the build message `The project was built assuming it is hosted at /portfolio/` could not be verified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4797f842a0832cad5437279fb24324)