### PR TITLE
Fix GitHub Pages section navigation

### DIFF
--- a/src/components/NavLinks/NavStyles.js
+++ b/src/components/NavLinks/NavStyles.js
@@ -1,7 +1,53 @@
 import styled from 'styled-components';
 
 export const Nav = styled.nav`
-  ul { display:flex; flex-wrap:wrap; align-items:center; justify-content:center; gap:8px; list-style:none; margin:0; padding:0; }
-  a { display:block; color:#243238; text-decoration:none; font-weight:800; border:1px solid #d8d1c5; border-radius:999px; padding:10px 13px; background:rgba(255,250,240,.74); }
-  a:hover, a.active { border-color:#2d7f82; color:#11191d; }
+  width: 100%;
+
+  ul {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  a {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 44px;
+    color: #243238;
+    text-decoration: none;
+    font-weight: 800;
+    border: 1px solid #d8d1c5;
+    border-radius: 999px;
+    padding: 10px 14px;
+    background: rgba(255,250,240,.74);
+    line-height: 1.1;
+  }
+
+  a:hover,
+  a.active {
+    border-color: #2d7f82;
+    color: #11191d;
+  }
+
+  a:focus-visible {
+    outline: 3px solid #2d7f82;
+    outline-offset: 3px;
+  }
+
+  @media(max-width: 520px) {
+    ul {
+      gap: 8px;
+    }
+
+    a {
+      padding: 10px 12px;
+      font-size: .95rem;
+    }
+  }
 `;

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -4,6 +4,8 @@ import Card from '../../components/Card/Card';
 import { profile, projects, featuredProjects, projectCategories, capabilities, skills, journey } from '../../data/portfolioData';
 import { GlobalPortfolioStyle, HomeContainer, Hero, Eyebrow, PageTitle, HeroTitle, PageDescription, CtaRow, ButtonLink, HeroPanel, SignalGrid, Signal, Section, SectionHeader, FeaturedGrid, ContainerProject, FilterBar, FilterButton, CapabilityGrid, CapabilityCard, CaseStudy, DetailGrid, SkillsGrid, SkillCard, JourneyList, JourneyItem, ContactPanel } from './HomeStyles';
 
+const getSectionHref = (sectionId) => `${process.env.PUBLIC_URL || ''}/#${sectionId}`;
+
 const Home = () => {
   const [selectedCardId, setSelectedCardId] = useState(null);
   const [activeCategory, setActiveCategory] = useState('all');
@@ -27,8 +29,8 @@ const Home = () => {
           <HeroTitle>{profile.title}</HeroTitle>
           <PageDescription>{profile.summary} {profile.value}</PageDescription>
           <CtaRow>
-            <ButtonLink $variant="dark" href="#projets">Voir les projets</ButtonLink>
-            <ButtonLink href="#parcours">Voir le parcours</ButtonLink>
+            <ButtonLink $variant="dark" href={getSectionHref('projets')}>Voir les projets</ButtonLink>
+            <ButtonLink href={getSectionHref('parcours')}>Voir le parcours</ButtonLink>
             <ButtonLink href={profile.links.github} target="_blank" rel="noreferrer">GitHub</ButtonLink>
           </CtaRow>
         </div>


### PR DESCRIPTION
### Motivation
- Les ancres de la page d’accueil pointaient vers la racine (`/#...`) et sortaient du sous-dossier GitHub Pages `/portfolio`, cassant la navigation interne. 
- Il faut que les CTA et ancres utilisent `process.env.PUBLIC_URL` pour générer correctement `/portfolio/#...` et que la navigation reste accessible et adaptée au mobile.

### Description
- Ajout d’un helper `getSectionHref(sectionId)` utilisable pour générer les ancres GitHub Pages-aware et remplacement des CTA de la home pour utiliser ce helper dans `src/pages/Home/Home.jsx`.
- Amélioration CSS de la navigation pour un meilleur wrapping, taille de cible tactile minimale et focus visible sans changer l’identité visuelle dans `src/components/NavLinks/NavStyles.js`.
- La composante de liens du header (`src/components/NavLinks/NavLinks.jsx`) utilisait déjà `getSectionHref` pour les ancres et conserve `NavLink` pour les routes `"/"` et `"/cv"`.
- Fichiers modifiés : `src/pages/Home/Home.jsx`, `src/components/NavLinks/NavStyles.js`.

### Testing
- Exécution de `npm ci` a réussi without errors. 
- Exécution de `npm run build` a réussi et le build affiche : `The project was built assuming it is hosted at /portfolio/.`.
- `git diff --check` et `git status --short` ont été exécutés et ne signalent pas d’erreurs ou de fichiers binaires modifiés.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a479ba95a34832cb4bc01e53b6ded67)