### PR TITLE
Amélioration visuelle : grille projets réactive, cartes premium, hero et animations

### DIFF
--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -1,20 +1,45 @@
 const navToggle = document.querySelector('.nav-toggle');
 const nav = document.querySelector('.site-nav');
+
 navToggle?.addEventListener('click', () => {
   const expanded = navToggle.getAttribute('aria-expanded') === 'true';
   navToggle.setAttribute('aria-expanded', String(!expanded));
   nav?.classList.toggle('is-open', !expanded);
 });
 
-document.querySelectorAll('[data-filter]').forEach((button) => {
+const filterButtons = document.querySelectorAll('[data-filter]');
+filterButtons.forEach((button) => {
+  button.setAttribute('aria-pressed', button.classList.contains('is-active') ? 'true' : 'false');
+
   button.addEventListener('click', () => {
     const filter = button.dataset.filter;
-    document.querySelectorAll('[data-filter]').forEach((item) => item.classList.toggle('is-active', item === button));
+
+    filterButtons.forEach((item) => {
+      const active = item === button;
+      item.classList.toggle('is-active', active);
+      item.setAttribute('aria-pressed', String(active));
+    });
+
     document.querySelectorAll('[data-project-card]').forEach((card) => {
       card.hidden = filter !== 'all' && card.dataset.category !== filter;
     });
   });
 });
+
+const revealElements = document.querySelectorAll('[data-reveal]');
+if ('IntersectionObserver' in window && !window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+  const revealObserver = new IntersectionObserver((entries, observer) => {
+    entries.forEach((entry) => {
+      if (!entry.isIntersecting) return;
+      entry.target.classList.add('is-revealed');
+      observer.unobserve(entry.target);
+    });
+  }, { rootMargin: '0px 0px -8% 0px', threshold: 0.12 });
+
+  revealElements.forEach((element) => revealObserver.observe(element));
+} else {
+  revealElements.forEach((element) => element.classList.add('is-revealed'));
+}
 
 document.querySelectorAll('[data-project-open]').forEach((button) => {
   button.addEventListener('click', () => {

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -4,8 +4,10 @@ import type { Project } from '../data/portfolioData';
 const { project, index = 0 } = Astro.props as { project: Project; index?: number };
 const links = project.links ?? {};
 ---
-<article class:list={["project-card", project.featured && "is-featured"]} data-project-card data-category={project.category} style={`--accent:${project.accent}`}>
-  <img src={project.image.src} alt={project.imageAlt} loading={index < 3 ? 'eager' : 'lazy'} decoding="async" />
+<article class:list={["project-card", project.featured && "is-featured"]} data-project-card data-reveal data-category={project.category} style={`--accent:${project.accent};--reveal-delay:${Math.min(index % 4, 3) * 80}ms`}>
+  <div class="project-card__media">
+    <img src={project.image.src} alt={project.imageAlt} loading={index < 3 ? 'eager' : 'lazy'} decoding="async" />
+  </div>
   <div class="project-card__body">
     <div class="project-card__meta">
       <span>{project.status}</span>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,16 +9,71 @@ import '../styles/global.css';
 import { withBase } from '../utils/paths';
 const archives = projects.filter((p) => p.category === 'archives');
 ---
-<!doctype html><html lang="fr"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width"/><meta name="description" content="Portfolio de Steve Bell, développeur fullstack Java Angular et Data Analyst junior : applications métier, API sécurisées, SQL, dashboards et projets data."/><title>Steve Bell — Fullstack Java Angular & Data Analyst junior</title></head><body>
-<Header />
-<main>
-  <section class="hero" aria-labelledby="hero-title"><div><p class="eyebrow">Portfolio statique · Fullstack · Data</p><h1 id="hero-title">{profile.name}<span>{profile.title}</span></h1><p class="hero__lead">{profile.value}</p><div class="hero__actions"><a class="button" href="#case-studies">Voir les projets clés</a><a class="button button--ghost" href={withBase('cv/')}>CV synthétique</a></div></div><aside><strong>Focus 2026</strong><p>Applications métier Java/Angular, SQL décisionnel, qualité de données et restitution claire.</p><ul>{capabilities.map((cap) => <li><b>{cap.title}</b><span>{cap.text}</span></li>)}</ul></aside></section>
-  <section id="case-studies" class="section"><SectionHeader eyebrow="Case studies" title="5 projets qui résument le positionnement" text="Des applications métier et des projets data détaillés par contexte, problème, livrables et impact."/><div class="featured-grid">{featuredProjects.map((project, index) => <ProjectCard project={project} index={index} />)}</div></section>
-  <section id="projets" class="section"><SectionHeader eyebrow="Portfolio" title="Projets, outils et archives" text="Les archives OpenClassrooms restent visibles, mais les projets actuels et data sont prioritaires."/><div class="filters" aria-label="Filtrer les projets">{projectCategories.map((cat) => <button type="button" data-filter={cat.id} class={cat.id === 'all' ? 'is-active' : ''}>{cat.label}</button>)}</div><div class="project-grid" data-project-grid>{projects.map((project, index) => <ProjectCard project={project} index={index} />)}</div><p class="archive-note">Archives OpenClassrooms visibles : {archives.length} projets secondaires documentant la progression web.</p></section>
-  <section id="competences" class="section split"><SectionHeader eyebrow="Compétences" title="Un socle fullstack complété par la donnée"/><div class="skill-grid">{skills.map((group) => <article><h3>{group.group}</h3><ul>{group.items.map((item) => <li>{item}</li>)}</ul></article>)}</div></section>
-  <section id="parcours" class="section"><SectionHeader eyebrow="Parcours" title="Progression orientée usage réel"/><ol class="timeline">{journey.map((step) => <li><span>{step.period}</span><h3>{step.title}</h3><p>{step.text}</p></li>)}</ol></section>
-</main>
-{projects.map((project) => <ProjectDetails project={project} />)}
-<Footer />
-<script src={withBase('scripts/main.js')} defer></script>
-</body></html>
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <meta name="description" content="Portfolio de Steve Bell, développeur fullstack Java Angular et Data Analyst junior : applications métier, API sécurisées, SQL, dashboards et projets data." />
+    <title>Steve Bell — Fullstack Java Angular & Data Analyst junior</title>
+  </head>
+  <body>
+    <Header />
+    <main>
+      <section class="hero" aria-labelledby="hero-title" data-reveal>
+        <div class="hero__content">
+          <p class="eyebrow">Portfolio statique · Fullstack · Data</p>
+          <h1 id="hero-title">{profile.name}<span>{profile.title}</span></h1>
+          <p class="hero__lead">{profile.value}</p>
+          <div class="hero__chips" aria-label="Repères portfolio">
+            <span>22 projets</span>
+            <span>5 case studies</span>
+            <span>Fullstack + Data</span>
+            <span>Astro / GitHub Pages</span>
+          </div>
+          <div class="hero__actions">
+            <a class="button" href="#case-studies">Voir les projets clés</a>
+            <a class="button button--ghost" href={withBase('cv/')}>CV synthétique</a>
+          </div>
+        </div>
+        <aside class="hero__focus" data-reveal>
+          <div class="hero__focus-head">
+            <span aria-hidden="true"></span>
+            <div>
+              <strong>Focus 2026</strong>
+              <p>Applications métier Java/Angular, SQL décisionnel, qualité de données et restitution claire.</p>
+            </div>
+          </div>
+          <ul>
+            {capabilities.map((cap) => <li><b>{cap.title}</b><span>{cap.text}</span></li>)}
+          </ul>
+        </aside>
+      </section>
+
+      <section id="case-studies" class="section" data-reveal>
+        <SectionHeader eyebrow="Case studies" title="5 projets qui résument le positionnement" text="Des applications métier et des projets data détaillés par contexte, problème, livrables et impact." />
+        <div class="featured-grid">{featuredProjects.map((project, index) => <ProjectCard project={project} index={index} />)}</div>
+      </section>
+
+      <section id="projets" class="section" data-reveal>
+        <SectionHeader eyebrow="Portfolio" title="Projets, outils et archives" text="Les archives OpenClassrooms restent visibles, mais les projets actuels et data sont prioritaires." />
+        <div class="filters" aria-label="Filtrer les projets">{projectCategories.map((cat) => <button type="button" data-filter={cat.id} class={cat.id === 'all' ? 'is-active' : ''}>{cat.label}</button>)}</div>
+        <div class="project-grid" data-project-grid>{projects.map((project, index) => <ProjectCard project={project} index={index} />)}</div>
+        <p class="archive-note">Archives OpenClassrooms visibles : {archives.length} projets secondaires documentant la progression web.</p>
+      </section>
+
+      <section id="competences" class="section split" data-reveal>
+        <SectionHeader eyebrow="Compétences" title="Un socle fullstack complété par la donnée" />
+        <div class="skill-grid">{skills.map((group) => <article data-reveal><h3>{group.group}</h3><ul>{group.items.map((item) => <li>{item}</li>)}</ul></article>)}</div>
+      </section>
+
+      <section id="parcours" class="section" data-reveal>
+        <SectionHeader eyebrow="Parcours" title="Progression orientée usage réel" />
+        <ol class="timeline">{journey.map((step) => <li data-reveal><span>{step.period}</span><h3>{step.title}</h3><p>{step.text}</p></li>)}</ol>
+      </section>
+    </main>
+    {projects.map((project) => <ProjectDetails project={project} />)}
+    <Footer />
+    <script src={withBase('scripts/main.js')} defer></script>
+  </body>
+</html>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,1 +1,250 @@
-:root{--bg:#f5f1e8;--ink:#17201d;--muted:#66716b;--panel:#fffaf0;--line:#ded5c4;--accent:#2d7f82;--dark:#101615}*{box-sizing:border-box}html{scroll-behavior:smooth}body{margin:0;background:var(--bg);color:var(--ink);font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;line-height:1.6}a{color:inherit}img{display:block;max-width:100%;height:auto}button,a{outline-offset:4px}:focus-visible{outline:3px solid #d98b35}.site-header{position:sticky;top:0;z-index:10;display:flex;align-items:center;justify-content:space-between;gap:1rem;padding:1rem clamp(1rem,4vw,4rem);background:rgba(245,241,232,.92);backdrop-filter:blur(14px);border-bottom:1px solid var(--line)}.brand{display:flex;align-items:center;gap:.7rem;text-decoration:none}.brand span{display:grid;place-items:center;width:2.5rem;height:2.5rem;background:var(--dark);color:#f4d7a1;border-radius:50%;font-weight:800}.site-nav{display:flex;gap:1rem;font-size:.95rem}.site-nav a{text-decoration:none;color:var(--muted)}.site-nav a:hover{color:var(--ink)}.nav-toggle{display:none}.hero{display:grid;grid-template-columns:minmax(0,1.2fr) minmax(18rem,.8fr);gap:2rem;min-height:78vh;padding:clamp(4rem,9vw,8rem) clamp(1rem,4vw,4rem);align-items:center}.eyebrow{text-transform:uppercase;letter-spacing:.16em;font-size:.75rem;font-weight:800;color:var(--accent);margin:0 0 .75rem}.hero h1{font-size:clamp(3.2rem,10vw,8rem);line-height:.9;letter-spacing:-.08em;margin:0}.hero h1 span{display:block;font-size:clamp(1.2rem,2.5vw,2rem);letter-spacing:-.02em;line-height:1.2;margin-top:1rem;max-width:55rem}.hero__lead{font-size:clamp(1.2rem,2vw,1.7rem);max-width:56rem;color:#39443f}.hero aside,.project-card,.skill-grid article,.timeline li,.site-footer,.project-dialog__panel{background:var(--panel);border:1px solid var(--line);box-shadow:0 20px 60px rgba(38,31,21,.08)}.hero aside{padding:1.5rem;border-radius:1.5rem}.hero aside ul{display:grid;gap:1rem;padding:0;margin:1rem 0 0;list-style:none}.hero aside li span{display:block;color:var(--muted)}.button{display:inline-flex;align-items:center;justify-content:center;border:1px solid var(--dark);background:var(--dark);color:#fff;text-decoration:none;border-radius:999px;padding:.85rem 1.1rem;font-weight:800;cursor:pointer}.button--ghost{background:transparent;color:var(--dark)}.hero__actions,.project-card__actions{display:flex;flex-wrap:wrap;gap:.75rem;align-items:center}.section{padding:clamp(3rem,7vw,6rem) clamp(1rem,4vw,4rem)}.section-header{max-width:58rem;margin-bottom:2rem}.section-header h2{font-size:clamp(2rem,5vw,4.5rem);line-height:1;margin:.2rem 0;letter-spacing:-.05em}.featured-grid{display:grid;grid-template-columns:repeat(5,minmax(16rem,1fr));gap:1rem;overflow-x:auto;padding-bottom:1rem}.project-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(18rem,1fr));gap:1rem}.project-card{border-radius:1.2rem;overflow:hidden;border-top:5px solid var(--accent)}.project-card img{width:100%;aspect-ratio:16/10;object-fit:cover;background:#ddd6ca}.project-card__body{padding:1rem}.project-card__meta{display:flex;justify-content:space-between;gap:.5rem;color:var(--muted);font-size:.78rem;text-transform:uppercase;letter-spacing:.08em}.project-card h3{font-size:1.35rem;line-height:1.1}.tags{display:flex;flex-wrap:wrap;gap:.4rem;padding:0;margin:1rem 0;list-style:none}.tags li{border:1px solid color-mix(in srgb,var(--accent),#fff 55%);background:color-mix(in srgb,var(--accent),#fff 88%);border-radius:999px;padding:.25rem .55rem;font-size:.78rem}.text-link{font-weight:800;color:var(--accent)}.filters{display:flex;flex-wrap:wrap;gap:.5rem;margin-bottom:1.5rem}.filters button{border:1px solid var(--line);background:#fff8ea;border-radius:999px;padding:.7rem 1rem;cursor:pointer}.filters .is-active{background:var(--dark);color:#fff}.skill-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(15rem,1fr));gap:1rem}.skill-grid article{padding:1.2rem;border-radius:1rem}.timeline{display:grid;grid-template-columns:repeat(auto-fit,minmax(16rem,1fr));gap:1rem;padding:0;list-style:none}.timeline li{padding:1.2rem;border-radius:1rem}.timeline span{font-weight:800;color:var(--accent)}.site-footer{margin:clamp(1rem,4vw,4rem);padding:2rem;border-radius:1.5rem;display:flex;justify-content:space-between;gap:2rem}.site-footer address{display:grid;gap:.7rem;font-style:normal}.project-dialog{border:0;padding:0;background:transparent;max-width:min(920px,94vw)}.project-dialog::backdrop{background:rgba(16,22,21,.72)}.project-dialog__panel{padding:clamp(1rem,4vw,2rem);border-radius:1.2rem;border-top:6px solid var(--accent);max-height:88vh;overflow:auto}.dialog-close{float:right;border:0;background:var(--dark);color:white;border-radius:50%;width:2.4rem;height:2.4rem;font-size:1.4rem;cursor:pointer}.detail-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(14rem,1fr));gap:1rem}.archive-note{color:var(--muted)}.cv-list{display:grid;gap:1rem}.not-found{min-height:70vh}@media (max-width:800px){.hero{grid-template-columns:1fr;min-height:auto}.nav-toggle{display:inline-flex;border:1px solid var(--line);background:#fff8ea;border-radius:999px;padding:.65rem 1rem}.site-nav{display:none;position:absolute;right:1rem;top:4.5rem;flex-direction:column;background:var(--panel);padding:1rem;border:1px solid var(--line);border-radius:1rem}.site-nav.is-open{display:flex}.site-footer{flex-direction:column}.featured-grid{grid-template-columns:1fr;overflow:visible}.hero h1{font-size:3.5rem}}
+/* tokens */
+:root {
+  --bg: #f5f1e8;
+  --ink: #17201d;
+  --muted: #66716b;
+  --panel: #fffaf0;
+  --panel-strong: #fffdf7;
+  --line: #ded5c4;
+  --accent: #2d7f82;
+  --dark: #101615;
+  --shadow-soft: 0 20px 60px rgba(38, 31, 21, 0.08);
+  --shadow-card: 0 18px 45px rgba(38, 31, 21, 0.12);
+  --shadow-hover: 0 26px 70px rgba(38, 31, 21, 0.18);
+  --radius-lg: 1.5rem;
+  --radius-md: 1.1rem;
+  --wrap: min(100%, 1500px);
+}
+
+/* base */
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0;
+  background:
+    radial-gradient(circle at 10% 10%, rgba(45, 127, 130, 0.08), transparent 28rem),
+    radial-gradient(circle at 90% 0%, rgba(217, 139, 53, 0.10), transparent 22rem),
+    var(--bg);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.6;
+}
+a { color: inherit; }
+img { display: block; max-width: 100%; height: auto; }
+button, a { outline-offset: 4px; }
+:focus-visible { outline: 3px solid #d98b35; }
+
+/* header */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem clamp(1rem, 4vw, 4rem);
+  background: rgba(245, 241, 232, 0.92);
+  backdrop-filter: blur(14px);
+  border-bottom: 1px solid var(--line);
+}
+.brand { display: flex; align-items: center; gap: 0.7rem; text-decoration: none; }
+.brand span {
+  display: grid;
+  place-items: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  background: var(--dark);
+  color: #f4d7a1;
+  border-radius: 50%;
+  font-weight: 800;
+}
+.site-nav { display: flex; gap: 1rem; font-size: 0.95rem; }
+.site-nav a { text-decoration: none; color: var(--muted); transition: color 180ms ease; }
+.site-nav a:hover { color: var(--ink); }
+.nav-toggle { display: none; }
+
+/* hero */
+.hero {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(20rem, 0.85fr);
+  gap: clamp(1.5rem, 4vw, 4rem);
+  min-height: 78vh;
+  padding: clamp(4rem, 9vw, 8rem) clamp(1rem, 4vw, 4rem);
+  align-items: center;
+  overflow: hidden;
+}
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: 3rem clamp(1rem, 4vw, 4rem) auto auto;
+  width: min(42vw, 34rem);
+  aspect-ratio: 1;
+  border-radius: 42% 58% 52% 48%;
+  background: linear-gradient(135deg, rgba(45, 127, 130, 0.14), rgba(217, 139, 53, 0.08));
+  filter: blur(1px);
+  z-index: -1;
+}
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+.hero h1 { margin: 0; font-size: clamp(3.2rem, 10vw, 8rem); line-height: 0.9; letter-spacing: -0.08em; }
+.hero h1 span { display: block; max-width: 55rem; margin-top: 1rem; font-size: clamp(1.2rem, 2.5vw, 2rem); line-height: 1.2; letter-spacing: -0.02em; }
+.hero__lead { max-width: 56rem; color: #39443f; font-size: clamp(1.2rem, 2vw, 1.7rem); }
+.hero__chips { display: flex; flex-wrap: wrap; gap: 0.65rem; margin: 1.4rem 0; }
+.hero__chips span {
+  border: 1px solid color-mix(in srgb, var(--accent), #fff 58%);
+  background: rgba(255, 250, 240, 0.72);
+  border-radius: 999px;
+  padding: 0.55rem 0.8rem;
+  color: #31403a;
+  font-size: 0.9rem;
+  font-weight: 800;
+  box-shadow: 0 10px 30px rgba(38, 31, 21, 0.06);
+}
+.hero__actions, .project-card__actions { display: flex; flex-wrap: wrap; gap: 0.75rem; align-items: center; }
+.hero__focus, .project-card, .skill-grid article, .timeline li, .site-footer, .project-dialog__panel {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  box-shadow: var(--shadow-soft);
+}
+.hero__focus { border-radius: var(--radius-lg); padding: clamp(1.2rem, 3vw, 1.8rem); }
+.hero__focus-head { display: grid; grid-template-columns: auto 1fr; gap: 1rem; align-items: start; }
+.hero__focus-head > span { width: 0.85rem; height: 3.2rem; border-radius: 999px; background: linear-gradient(var(--accent), #d98b35); box-shadow: 0 0 0 8px color-mix(in srgb, var(--accent), transparent 86%); }
+.hero__focus strong { display: block; font-size: 1.35rem; letter-spacing: -0.03em; }
+.hero__focus p { margin: 0.25rem 0 0; color: var(--muted); }
+.hero__focus ul { display: grid; grid-template-columns: 1fr 1fr; gap: 0.8rem; padding: 0; margin: 1.3rem 0 0; list-style: none; }
+.hero__focus li { padding: 0.85rem; border: 1px solid color-mix(in srgb, var(--line), #fff 40%); border-radius: 1rem; background: rgba(255,255,255,0.38); }
+.hero__focus li span { display: block; color: var(--muted); font-size: 0.9rem; }
+
+/* sections */
+.section { padding: clamp(3rem, 7vw, 6rem) clamp(1rem, 4vw, 4rem); }
+.section-header { max-width: 58rem; margin-bottom: 2rem; }
+.section-header h2 { margin: 0.2rem 0; font-size: clamp(2rem, 5vw, 4.5rem); line-height: 1; letter-spacing: -0.05em; }
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--dark);
+  background: var(--dark);
+  color: #fff;
+  text-decoration: none;
+  border-radius: 999px;
+  padding: 0.85rem 1.1rem;
+  font-weight: 800;
+  cursor: pointer;
+  transition: transform 180ms ease, box-shadow 180ms ease, background 180ms ease, border-color 180ms ease;
+}
+.button:hover { transform: translateY(-1px); box-shadow: 0 12px 25px rgba(16, 22, 21, 0.16); }
+.button--ghost { background: transparent; color: var(--dark); }
+
+/* project cards */
+.featured-grid, .project-grid {
+  display: grid;
+  width: var(--wrap);
+  max-width: 100%;
+  margin-inline: auto;
+  gap: clamp(1rem, 2vw, 1.35rem);
+  grid-template-columns: 1fr;
+}
+.project-card {
+  position: relative;
+  display: flex;
+  min-height: 100%;
+  flex-direction: column;
+  overflow: hidden;
+  border-radius: var(--radius-md);
+  transition: transform 220ms ease, box-shadow 220ms ease, border-color 220ms ease;
+}
+.project-card::before { content: ""; height: 5px; background: linear-gradient(90deg, var(--accent), color-mix(in srgb, var(--accent), #fff 52%)); }
+.project-card__media { overflow: hidden; background: #ddd6ca; }
+.project-card img { width: 100%; aspect-ratio: 16 / 9; object-fit: cover; transition: transform 450ms ease, filter 220ms ease; }
+.project-card__body { display: flex; flex: 1; flex-direction: column; padding: 1.15rem; }
+.project-card__meta { display: flex; justify-content: space-between; gap: 0.5rem; color: var(--muted); font-size: 0.74rem; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; }
+.project-card h3 { margin: 0.85rem 0 0.45rem; font-size: 1.35rem; line-height: 1.1; letter-spacing: -0.03em; }
+.project-card p { margin: 0; color: #43504a; }
+.project-card .tags { margin-top: auto; }
+.project-card:hover { transform: translateY(-4px); border-color: color-mix(in srgb, var(--accent), var(--line) 45%); box-shadow: var(--shadow-hover); }
+.project-card:hover img { transform: scale(1.045); filter: saturate(1.05) contrast(1.03); }
+.tags { display: flex; flex-wrap: wrap; gap: 0.45rem; padding: 0; margin: 1rem 0; list-style: none; }
+.tags li { border: 1px solid color-mix(in srgb, var(--accent), #fff 55%); background: color-mix(in srgb, var(--accent), #fff 88%); border-radius: 999px; padding: 0.28rem 0.62rem; font-size: 0.78rem; font-weight: 750; }
+.text-link { color: var(--accent); font-weight: 900; text-decoration-thickness: 0.12em; text-underline-offset: 0.2em; }
+
+/* filters */
+.filters { display: flex; flex-wrap: wrap; gap: 0.55rem; margin-bottom: 1.5rem; }
+.filters button { border: 1px solid var(--line); background: #fff8ea; border-radius: 999px; padding: 0.72rem 1rem; color: #39443f; font-weight: 800; cursor: pointer; transition: transform 180ms ease, border-color 180ms ease, background 180ms ease, color 180ms ease, box-shadow 180ms ease; }
+.filters button:hover { transform: translateY(-1px); border-color: color-mix(in srgb, var(--accent), var(--line) 30%); box-shadow: 0 10px 25px rgba(38, 31, 21, 0.08); }
+.filters .is-active { border-color: var(--dark); background: var(--dark); color: #fff; box-shadow: inset 0 -3px 0 var(--accent); }
+.archive-note { color: var(--muted); }
+
+/* skills */
+.skill-grid { display: grid; gap: 1rem; grid-template-columns: 1fr; }
+.skill-grid article { padding: 1.25rem; border-radius: 1rem; border-top: 4px solid color-mix(in srgb, var(--accent), #d98b35 35%); }
+.skill-grid h3 { margin: 0 0 0.8rem; padding-bottom: 0.65rem; border-bottom: 1px solid var(--line); letter-spacing: -0.02em; }
+.skill-grid ul { display: flex; flex-wrap: wrap; gap: 0.45rem; padding: 0; margin: 0; list-style: none; }
+.skill-grid li { border-radius: 999px; background: #fff5df; padding: 0.35rem 0.6rem; color: #47534e; font-size: 0.9rem; font-weight: 700; }
+
+/* timeline */
+.timeline { display: grid; grid-template-columns: 1fr; gap: 1rem; padding: 0; list-style: none; }
+.timeline li { padding: 1.2rem; border-radius: 1rem; }
+.timeline span { color: var(--accent); font-weight: 800; }
+.timeline h3 { margin-bottom: 0.25rem; }
+
+/* dialog */
+.project-dialog { border: 0; padding: 0; background: transparent; max-width: min(960px, 94vw); }
+.project-dialog::backdrop { background: rgba(16, 22, 21, 0.72); backdrop-filter: blur(3px); }
+.project-dialog[open] .project-dialog__panel { animation: dialog-in 180ms ease-out; }
+.project-dialog__panel { max-height: 88vh; overflow: auto; padding: clamp(1rem, 4vw, 2rem); border-radius: 1.2rem; border-top: 6px solid var(--accent); }
+.dialog-close { float: right; border: 0; background: var(--dark); color: white; border-radius: 50%; width: 2.4rem; height: 2.4rem; font-size: 1.4rem; cursor: pointer; }
+.lead { color: #39443f; font-size: 1.08rem; }
+.detail-grid { display: grid; grid-template-columns: 1fr; gap: 1rem; }
+.detail-grid section { padding: 1rem; border: 1px solid var(--line); border-radius: 1rem; background: rgba(255,255,255,0.42); }
+.detail-grid h4, .project-dialog__panel h4 { margin: 0 0 0.4rem; color: color-mix(in srgb, var(--accent), var(--ink) 35%); }
+.detail-grid p { margin: 0; }
+.cv-list { display: grid; gap: 1rem; }
+.not-found { min-height: 70vh; }
+.site-footer { margin: clamp(1rem, 4vw, 4rem); padding: 2rem; border-radius: var(--radius-lg); display: flex; justify-content: space-between; gap: 2rem; }
+.site-footer address { display: grid; gap: 0.7rem; font-style: normal; }
+
+/* responsive */
+@media (min-width: 680px) {
+  .featured-grid, .project-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .skill-grid, .timeline { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .detail-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+@media (min-width: 1024px) {
+  .featured-grid, .project-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .skill-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .timeline { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+}
+@media (min-width: 1680px) {
+  .featured-grid, .project-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+  .skill-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+}
+@media (max-width: 800px) {
+  .hero { grid-template-columns: 1fr; min-height: auto; }
+  .hero h1 { font-size: 3.5rem; }
+  .hero__focus ul { grid-template-columns: 1fr; }
+  .nav-toggle { display: inline-flex; border: 1px solid var(--line); background: #fff8ea; border-radius: 999px; padding: 0.65rem 1rem; }
+  .site-nav { display: none; position: absolute; right: 1rem; top: 4.5rem; flex-direction: column; background: var(--panel); padding: 1rem; border: 1px solid var(--line); border-radius: 1rem; }
+  .site-nav.is-open { display: flex; }
+  .site-footer { flex-direction: column; }
+}
+
+/* animations */
+[data-reveal] { opacity: 0; transform: translateY(18px); transition: opacity 520ms ease, transform 520ms ease; transition-delay: var(--reveal-delay, 0ms); }
+[data-reveal].is-revealed { opacity: 1; transform: none; }
+@keyframes dialog-in { from { opacity: 0; transform: translateY(12px) scale(0.98); } to { opacity: 1; transform: none; } }
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+  *, *::before, *::after { animation-duration: 0.001ms !important; animation-iteration-count: 1 !important; scroll-behavior: auto !important; transition-duration: 0.001ms !important; }
+  [data-reveal] { opacity: 1; transform: none; }
+  .project-card:hover, .button:hover, .filters button:hover { transform: none; }
+  .project-card:hover img { transform: none; }
+}


### PR DESCRIPTION
### Motivation
- Rendre le portfolio plus professionnel et lisible sans changer la stack, en particulier sur la densité des cartes projets, le rendu des images, les animations et la hiérarchie visuelle.

### Description
- Réorganisation du hero et ajout de chips/statuts et d’un panneau “Focus 2026” plus soigné sans images externes (modifié `src/pages/index.astro`).
- Reformatage complet de `src/styles/global.css` (tokens, base, header, hero, sections, project cards, filters, skills, timeline, dialog, responsive, animations) et mise en place d’une grille contrôlée : mobile 1 colonne, >=680px → 2 colonnes, >=1024px → `repeat(3, minmax(0, 1fr))`, >=1680px → `repeat(4, minmax(0, 1fr))` ; largeur max centrée via `--wrap` pour éviter qu’une carte isolée ne s’étire.
- Cartes projet : wrapper `.project-card__media`, images avec `aspect-ratio:16/9`, hover sobre avec zoom interne, ombre/translateY léger, accent coloré et hauteur cohérente (modifié `src/components/ProjectCard.astro` et `src/styles/global.css`).
- Ajout d’animations d’apparition légères via `data-reveal` sur sections, cartes, compétences et timeline et d’un `IntersectionObserver` propre avec fallback `prefers-reduced-motion` (nouveau/édité `public/scripts/main.js` et `src/pages/index.astro` pour hooks). 
- Améliorations d’accessibilité et d’UX : boutons de filtre conservent `aria-pressed` et état visuel, modales/dialogs ont animation d’ouverture douce et meilleur contraste/organisation des sections de détail.

### Testing
- `npm ci` — succès (install des dépendances terminé). 
- `ASTRO_TELEMETRY_DISABLED=1 npm run build` — build statique complet réussi (3 pages générées). 
- Recherche automatique : aucune occurrence de `/portfoliocv` ni `/portfolioscripts` trouvée, et `dist/`, `.astro/` et `node_modules/` restent ignorés (pas de fichiers binaires modifiés). 
- Vérification CSS : présence des règles `repeat(3, minmax(0, 1fr))` (desktop) et `repeat(4, minmax(0, 1fr))` (très grand écran), et absence d’`auto-fit/auto-fill` sur les grilles critiques.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48f388e188832ca51ab281b7246562)