### PR TITLE
Fix project filters and refresh portfolio data

### DIFF
--- a/TODO_ASSETS.md
+++ b/TODO_ASSETS.md
@@ -10,3 +10,9 @@ Aucun fichier binaire ne doit être généré automatiquement dans ce repository
 - `guide-investissement-dashboard.webp` : aperçu dashboard Guide Investissement.
 - `recettes-app.webp` : aperçu application Recettes avec liste, portions et courses.
 - `sportsee-dashboard.webp` : capture dashboard SportSee avec graphiques et KPI utilisateur.
+- `locatech.webp` : capture à créer manuellement quand le projet Locatech aura une interface ou documentation exploitable.
+- `locmns.webp` : capture à créer manuellement pour le projet LocMNS.
+- `bdshop.webp` : capture à créer manuellement pour BDSHOP.
+- `compressor-img.webp` : capture à créer manuellement pour l’outil compressorImg.
+- `doma-apero-site.webp` : capture à créer manuellement pour DomaAperoSite.
+- `exercices-progression.webp` : visuel de regroupement à créer manuellement pour les exercices MNS / progression.

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -7,12 +7,31 @@ navToggle?.addEventListener('click', () => {
   nav?.classList.toggle('is-open', !expanded);
 });
 
+const projectGrid = document.querySelector('[data-project-grid]');
 const filterButtons = document.querySelectorAll('[data-filter]');
+const emptyState = document.querySelector('[data-project-empty]');
+const catalogCards = projectGrid ? projectGrid.querySelectorAll('[data-project-card]') : [];
+
+const applyProjectFilter = (filter) => {
+  let visibleCount = 0;
+
+  catalogCards.forEach((card) => {
+    const shouldShow = filter === 'all' || card.dataset.category === filter;
+    card.hidden = !shouldShow;
+    card.classList.toggle('is-filtered-out', !shouldShow);
+    if (shouldShow) visibleCount += 1;
+  });
+
+  if (emptyState) {
+    emptyState.hidden = visibleCount > 0;
+  }
+};
+
 filterButtons.forEach((button) => {
   button.setAttribute('aria-pressed', button.classList.contains('is-active') ? 'true' : 'false');
 
   button.addEventListener('click', () => {
-    const filter = button.dataset.filter;
+    const filter = button.dataset.filter ?? 'all';
 
     filterButtons.forEach((item) => {
       const active = item === button;
@@ -20,9 +39,7 @@ filterButtons.forEach((button) => {
       item.setAttribute('aria-pressed', String(active));
     });
 
-    document.querySelectorAll('[data-project-card]').forEach((card) => {
-      card.hidden = filter !== 'all' && card.dataset.category !== filter;
-    });
+    applyProjectFilter(filter);
   });
 });
 

--- a/src/data/portfolioData.ts
+++ b/src/data/portfolioData.ts
@@ -92,8 +92,9 @@ export const skills = [
 
 export const journey = [
   { period: 'Aujourd’hui', title: 'Fullstack Java / Angular & Data / BI', text: "Positionnement centré sur les applications métier, la donnée exploitable, SQL, les dashboards et l'architecture front/back." },
+  { period: 'OpenClassrooms', title: 'Développeur concepteur web / logiciel React', text: 'Formation structurante en développement web et logiciel : React, Vue, Node.js, Express, MySQL, accessibilité, tests et documentation.' },
+  { period: 'Metz Numeric School', title: 'Concepteur logiciel Java / Angular', text: 'Formation orientée conception d’applications métier, Java, Angular, architecture front/back et pratiques professionnelles.' },
   { period: 'Formation data / BI', title: 'Analyse de données et modélisation', text: 'Projets de nettoyage, anonymisation RGPD, bases relationnelles PostgreSQL et analyses métier.' },
-  { period: 'OpenClassrooms', title: 'Développement web', text: 'Socle front-end puis fullstack : React, Vue, Node.js, Express, MySQL, accessibilité, tests et documentation.' },
   { period: 'Parcours terrain', title: 'Culture technique et usage réel', text: 'Expérience pratique issue de domaines techniques, utile pour comprendre les contraintes concrètes et les besoins opérationnels.' }
 ];
 
@@ -179,12 +180,81 @@ export const projects: Project[] = [
   },
   {
     id: 'guide-investissement', title: 'Guide Investissement', shortTitle: 'Outils finance perso', category: 'tools', featured: false, status: 'Projet personnel', period: '2026', role: 'Développeur front', image: imageFallback, imageAlt: 'Visuel temporaire pour le dashboard Guide Investissement', accent: '#8a6b2f',
-    stack: ['Astro', 'TypeScript', 'localStorage', 'GitHub Pages'], skills: ['SEO', 'Privacy-first', 'Scripts de vérification'], summary: 'Site éducatif statique avec outils interactifs, journal et dashboard personnel stockés localement.', context: 'Projet personnel orienté pédagogie financière et suivi local, sans collecte serveur ni compte utilisateur.', problem: 'Proposer un outil simple et privé pour suivre une démarche d’investissement personnelle.', solution: 'Architecture statique, données locales, contenus pédagogiques et contrôles automatisés.', deliverables: ['Site statique éducatif', 'Journal local', 'Dashboard personnel', 'Scripts de vérification'], decisions: ['Stocker les données dans le navigateur pour préserver la confidentialité', 'Favoriser des pages statiques compatibles GitHub Pages', 'Documenter les contrôles utiles avant publication'], learned: 'Structuration d’un outil privacy-first avec une attention SEO, contenu et vérification automatisée.', impact: 'Démontre une approche produit, SEO et respect de la confidentialité.', highlights: ['Journal', 'Dashboard', 'localStorage', 'SEO'], metrics: ['GitHub Pages', 'Privacy-first'], links: { repo: 'https://github.com/steve57000/guide-investissement' }
+    stack: ['Astro', 'TypeScript', 'localStorage', 'GitHub Pages'], skills: ['SEO', 'Privacy-first', 'Scripts de vérification'], summary: 'Site éducatif statique avec outils interactifs, journal et dashboard personnel stockés localement.', context: 'Projet personnel orienté pédagogie financière et suivi local, sans collecte serveur ni compte utilisateur.', problem: 'Proposer un outil simple et privé pour suivre une démarche d’investissement personnelle.', solution: 'Architecture statique, données locales, contenus pédagogiques et contrôles automatisés.', deliverables: ['Site statique éducatif', 'Journal local', 'Dashboard personnel', 'Scripts de vérification'], decisions: ['Stocker les données dans le navigateur pour préserver la confidentialité', 'Favoriser des pages statiques compatibles GitHub Pages', 'Documenter les contrôles utiles avant publication'], learned: 'Structuration d’un outil privacy-first avec une attention SEO, contenu et vérification automatisée.', impact: 'Démontre une approche produit, SEO et respect de la confidentialité.', highlights: ['Journal', 'Dashboard', 'localStorage', 'SEO'], metrics: ['GitHub Pages', 'Privacy-first'], links: { repo: 'https://github.com/steve57000/guide-investissement', demo: 'https://steve57000.github.io/guide-investissement/' }
   },
   {
-    id: 'recettes', title: 'Recettes', shortTitle: 'Livre de cuisine', category: 'tools', featured: false, status: 'Projet personnel', period: '2026', role: 'Développeur front', image: imageFallback, imageAlt: 'Visuel temporaire pour l’application Recettes', accent: '#a65a42', stack: ['JavaScript', 'HTML/CSS', 'localStorage', 'JSON'], skills: ['CRUD', 'Export/import', 'UX utilitaire'], summary: 'Application statique de recettes avec portions dynamiques, liste de courses et sauvegarde JSON.', context: 'Projet personnel conçu pour gérer des recettes du quotidien dans une application simple, portable et sans backend obligatoire.', problem: 'Organiser des recettes et courses sans backend obligatoire.', solution: 'CRUD local, calcul des portions, export/import et synchronisation JSON possible.', deliverables: ['Catalogue de recettes', 'Calcul des portions', 'Liste de courses', 'Export/import JSON'], decisions: ['Garder une application statique pour faciliter l’hébergement', 'Utiliser le stockage local et un format JSON lisible', 'Prioriser les actions utiles en cuisine plutôt qu’une interface complexe'], learned: 'Conception d’un outil utilitaire centré sur les usages réels : données locales, édition rapide et portabilité.', impact: 'Projet utile, concret et orienté usage quotidien.', highlights: ['CRUD', 'Portions dynamiques', 'Liste de courses', 'JSON'], metrics: ['localStorage', 'Application statique'], links: { repo: 'https://github.com/steve57000/recettes' }
+    id: 'recettes', title: 'Recettes', shortTitle: 'Livre de cuisine', category: 'tools', featured: false, status: 'Projet personnel', period: '2026', role: 'Développeur front', image: imageFallback, imageAlt: 'Visuel temporaire pour l’application Recettes', accent: '#a65a42', stack: ['JavaScript', 'HTML/CSS', 'localStorage', 'JSON'], skills: ['CRUD', 'Export/import', 'UX utilitaire'], summary: 'Application statique de recettes avec portions dynamiques, liste de courses et sauvegarde JSON.', context: 'Projet personnel conçu pour gérer des recettes du quotidien dans une application simple, portable et sans backend obligatoire.', problem: 'Organiser des recettes et courses sans backend obligatoire.', solution: 'CRUD local, calcul des portions, export/import et synchronisation JSON possible.', deliverables: ['Catalogue de recettes', 'Calcul des portions', 'Liste de courses', 'Export/import JSON'], decisions: ['Garder une application statique pour faciliter l’hébergement', 'Utiliser le stockage local et un format JSON lisible', 'Prioriser les actions utiles en cuisine plutôt qu’une interface complexe'], learned: 'Conception d’un outil utilitaire centré sur les usages réels : données locales, édition rapide et portabilité.', impact: 'Projet utile, concret et orienté usage quotidien.', highlights: ['CRUD', 'Portions dynamiques', 'Liste de courses', 'JSON'], metrics: ['localStorage', 'Application statique'], links: { repo: 'https://github.com/steve57000/recettes', demo: 'https://steve57000.github.io/recettes/' }
   },
-  { id: 'bt-carrelage', title: 'BT Carrelage', shortTitle: 'Site entreprise', category: 'fullstack', featured: false, status: 'Projet web', period: 'Projet existant', role: 'Développeur fullstack', image: btImage, imageAlt: 'Capture du site BT Carrelage', accent: '#6f5848', stack: ['React', 'Next.js', 'MongoDB'], skills: ['Cahier des charges', 'Guide technique', 'Site fullstack'], summary: 'Site pour une entreprise de carrelage, rénovation et aménagement intérieur.', problem: 'Présenter clairement une offre artisanale et ses services.', solution: 'Site web structuré autour des prestations, du savoir-faire et de la prise de contact.', impact: 'Expérience de conception et réalisation pour un contexte professionnel concret.', highlights: ['Cahier des charges', 'Guide technique', 'Responsive'], metrics: ['Site fullstack'], links: { demo: 'https://bt-carrelage.fr' } },
+
+  {
+    id: 'locatech', title: 'Locatech', shortTitle: 'Location matériel', category: 'fullstack', featured: false,
+    status: 'En cours / projet MNS', period: 'Formation MNS', role: 'Développeur fullstack', image: imageFallback, imageAlt: 'Visuel temporaire pour le projet Locatech', accent: '#3b6f8f',
+    stack: ['Projet MNS'], skills: ['Conception applicative', 'Documentation', 'Gestion de projet'],
+    summary: 'Projet MNS ajouté au portfolio comme application fullstack en cours, à documenter dès que le dépôt expose davantage d’éléments exploitables.',
+    context: 'Dépôt public repéré dans le périmètre portfolio, sans URL de démonstration fiable à rattacher.',
+    problem: 'Conserver une trace du projet sans inventer de fonctionnalités non vérifiées.',
+    solution: 'Fiche factuelle avec dépôt GitHub, catégorie probable fullstack et statut de projet MNS en cours.',
+    impact: 'Projet en cours permettant de suivre la progression Java / Angular et la conception applicative.',
+    highlights: ['Projet MNS', 'Dépôt public', 'Fiche à enrichir'], metrics: ['Statut en cours'],
+    links: { repo: 'https://github.com/steve57000/Locatech' }
+  },
+  {
+    id: 'locmns', title: 'LocMNS', shortTitle: 'Location MNS', category: 'fullstack', featured: false,
+    status: 'Projet MNS', period: 'Formation MNS', role: 'Développeur fullstack', image: imageFallback, imageAlt: 'Visuel temporaire pour le projet LocMNS', accent: '#507c62',
+    stack: ['Projet MNS'], skills: ['Conception applicative', 'Fullstack', 'Git'],
+    summary: 'Projet de formation MNS conservé comme réalisation fullstack, présenté factuellement en l’absence de démonstration fiable.',
+    problem: 'Documenter un projet de formation sans extrapoler au-delà des informations publiques disponibles.',
+    solution: 'Fiche synthétique orientée progression fullstack et lien vers le dépôt public.',
+    impact: 'Complète la lecture du parcours MNS et des projets applicatifs.',
+    highlights: ['Projet de formation', 'Dépôt public'], metrics: ['MNS'],
+    links: { repo: 'https://github.com/steve57000/LocMNS' }
+  },
+  {
+    id: 'bdshop', title: 'BDSHOP', shortTitle: 'Boutique', category: 'fullstack', featured: false,
+    status: 'Projet applicatif', period: 'Formation / pratique', role: 'Développeur fullstack', image: imageFallback, imageAlt: 'Visuel temporaire pour BDSHOP', accent: '#8f5a3b',
+    stack: ['Application web'], skills: ['Catalogue', 'Architecture applicative', 'Git'],
+    summary: 'Projet public de boutique en ligne, retenu comme exercice applicatif démonstratif plutôt que comme archive mineure.',
+    problem: 'Structurer une application orientée catalogue et parcours utilisateur.',
+    solution: 'Fiche portfolio prudente, centrée sur la valeur applicative et le dépôt public.',
+    impact: 'Ajoute un exemple de projet web métier au catalogue.',
+    highlights: ['Boutique', 'Projet public'], metrics: ['Application web'],
+    links: { repo: 'https://github.com/steve57000/BDSHOP' }
+  },
+  {
+    id: 'compressor-img', title: 'compressorImg', shortTitle: 'Compression images', category: 'tools', featured: false,
+    status: 'Outil personnel', period: 'Projet public', role: 'Développeur front / outil', image: imageFallback, imageAlt: 'Visuel temporaire pour compressorImg', accent: '#6d6a9f',
+    stack: ['Outil web'], skills: ['Optimisation', 'UX utilitaire', 'Front-end'],
+    summary: 'Outil public dédié à la compression d’images, classé dans les utilitaires pour ne pas diluer les projets majeurs.',
+    problem: 'Réduire le poids d’images dans un usage web ou portfolio.',
+    solution: 'Projet utilitaire présenté avec son dépôt, sans ajout de visuel binaire.',
+    impact: 'Montre une sensibilité à l’optimisation des assets et à la performance web.',
+    highlights: ['Compression', 'Optimisation images', 'Outil'], metrics: ['Projet utilitaire'],
+    links: { repo: 'https://github.com/steve57000/compressorImg' }
+  },
+  {
+    id: 'doma-apero-site', title: 'DomaAperoSite', shortTitle: 'Site vitrine', category: 'frontend', featured: false,
+    status: 'Projet vitrine', period: 'Projet public', role: 'Développeur front', image: imageFallback, imageAlt: 'Visuel temporaire pour DomaAperoSite', accent: '#b2773f',
+    stack: ['Site web'], skills: ['Intégration', 'Responsive', 'Présentation'],
+    summary: 'Site vitrine public ajouté comme projet front-end, avec présentation volontairement factuelle.',
+    problem: 'Présenter un contenu vitrine dans une interface web claire.',
+    solution: 'Projet classé front-end avec dépôt public et sans URL de démo non vérifiée.',
+    impact: 'Complète les réalisations front-end hors parcours OpenClassrooms.',
+    highlights: ['Site vitrine', 'Front-end'], metrics: ['Dépôt public'],
+    links: { repo: 'https://github.com/steve57000/DomaAperoSite' }
+  },
+  {
+    id: 'exercices-progression', title: 'Exercices MNS et progression', shortTitle: 'Exercices', category: 'archives', featured: false,
+    status: 'Archives / progression', period: 'Formation MNS', role: 'Apprenant développeur', image: imageFallback, imageAlt: 'Visuel temporaire pour les exercices de progression', accent: '#66717a',
+    stack: ['Java', 'React', 'TypeScript', 'Python', 'Exercices'], skills: ['Bases langage', 'Algorithmique', 'Pratique régulière'],
+    summary: 'Regroupement des dépôts d’exercices publics pour documenter la progression sans surcharger le portfolio de petites fiches.',
+    context: 'Dépôts évalués : mns-cda-java, react-basics, todo-list-react-tsx, toDoListJava, Grand-Frais, laurent, devoirMns, foretEnchantee et pythonExoMNS.',
+    problem: 'Garder une trace des exercices tout en priorisant les projets professionnels, complets ou démonstratifs.',
+    solution: 'Regrouper ces dépôts en une archive unique orientée progression.',
+    impact: 'Clarifie le catalogue : les exercices restent consultables sans concurrencer les projets majeurs.',
+    highlights: ['Java', 'React / TypeScript', 'Python', 'Exercices MNS'], metrics: ['Archives regroupées'],
+    links: { repo: 'https://github.com/steve57000?tab=repositories' }
+  },
+  { id: 'bt-carrelage', title: 'BT Carrelage', shortTitle: 'Site entreprise', category: 'fullstack', featured: false, status: 'Projet web', period: 'Projet existant', role: 'Développeur fullstack', image: btImage, imageAlt: 'Capture du site BT Carrelage', accent: '#6f5848', stack: ['React', 'Next.js', 'MongoDB'], skills: ['Cahier des charges', 'Guide technique', 'Site fullstack'], summary: 'Site pour une entreprise de carrelage, rénovation et aménagement intérieur.', problem: 'Présenter clairement une offre artisanale et ses services.', solution: 'Site web structuré autour des prestations, du savoir-faire et de la prise de contact.', impact: 'Expérience de conception et réalisation pour un contexte professionnel concret.', highlights: ['Cahier des charges', 'Guide technique', 'Responsive'], metrics: ['Site fullstack'], links: {} },
   { id: 'groupomania', title: 'Groupomania', shortTitle: 'Réseau social interne', category: 'fullstack', featured: false, status: 'Projet OpenClassrooms', period: 'Formation web', role: 'Développeur fullstack', image: groupomaniaImage, imageAlt: 'Capture du réseau social interne Groupomania', accent: '#c84b45', stack: ['Vue', 'Node.js', 'Express', 'MySQL', 'Sass'], skills: ['Auth', 'CRUD', 'Modération'], summary: "Réseau social d'entreprise avec posts, commentaires, likes, profil et modération admin.", problem: 'Créer un espace interne d’échange sécurisé.', solution: 'Frontend Vue, API Express, base MySQL et rôles de modération.', impact: 'Projet fondateur sur le fullstack JavaScript.', highlights: ['Authentification', 'Posts', 'Commentaires', 'Likes', 'Admin'], metrics: ['API REST', 'MySQL'], links: { repo: 'https://github.com/steve57000/Groupomania' } },
   { id: 'sportsee', title: 'SportSee', shortTitle: 'Dashboard sportif', category: 'frontend', featured: false, status: 'Projet OpenClassrooms', period: 'Formation web', role: 'Développeur front', image: imageFallback, imageAlt: 'Visuel temporaire pour le dashboard SportSee', accent: '#d35445', stack: ['React', 'D3', 'Axios'], skills: ['Dataviz', 'Composants', 'API'], summary: 'Dashboard sportif avec graphiques et indicateurs utilisateur.', problem: 'Rendre des données sportives lisibles sous forme de tableaux de bord.', solution: 'Composants React, intégration API et visualisations D3.', impact: 'Bon pont entre front-end et data visualisation.', highlights: ['Graphiques', 'KPI utilisateur', 'API'], metrics: ['React', 'D3'], links: { repo: 'https://github.com/steve57000/SportSee' } },
   { id: 'kasa', title: 'Kasa', shortTitle: 'Location immobilière', category: 'frontend', featured: false, status: 'Projet OpenClassrooms', period: 'Formation web', role: 'Développeur React', image: kasaImage, imageAlt: 'Capture de l’application de location Kasa', accent: '#ff6f61', stack: ['React', 'React Router', 'Composants'], skills: ['Routing', 'Composants', 'Responsive'], summary: 'Application de location avec pages logement, galeries, accordéons et routing.', problem: 'Construire une SPA structurée à partir de données logements.', solution: 'React Router, composants réutilisables et interface responsive.', impact: 'Renforce les bases React et architecture de composants.', highlights: ['Routing', 'Galleries', 'Accordions'], metrics: ['SPA React'], links: { repo: 'https://github.com/steve57000/kasa', demo: 'https://steve57000.github.io/kasa/' } },

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -26,7 +26,7 @@ const archives = projects.filter((p) => p.category === 'archives');
           <h1 id="hero-title">{profile.name}<span>{profile.title}</span></h1>
           <p class="hero__lead">{profile.value}</p>
           <div class="hero__chips" aria-label="Repères portfolio">
-            <span>22 projets</span>
+            <span>{projects.length} projets</span>
             <span>5 case studies</span>
             <span>Fullstack + Data</span>
             <span>Astro / GitHub Pages</span>
@@ -57,8 +57,9 @@ const archives = projects.filter((p) => p.category === 'archives');
 
       <section id="projets" class="section" data-reveal>
         <SectionHeader eyebrow="Portfolio" title="Projets, outils et archives" text="Les archives OpenClassrooms restent visibles, mais les projets actuels et data sont prioritaires." />
-        <div class="filters" aria-label="Filtrer les projets">{projectCategories.map((cat) => <button type="button" data-filter={cat.id} class={cat.id === 'all' ? 'is-active' : ''}>{cat.label}</button>)}</div>
+        <div class="filters" aria-label="Filtrer les projets">{projectCategories.map((cat) => <button type="button" data-filter={cat.id} class={cat.id === 'all' ? 'is-active' : ''} aria-pressed={cat.id === 'all' ? 'true' : 'false'}>{cat.label}</button>)}</div>
         <div class="project-grid" data-project-grid>{projects.map((project, index) => <ProjectCard project={project} index={index} />)}</div>
+        <p class="project-empty" data-project-empty aria-live="polite" hidden>Aucun projet dans ce filtre pour le moment.</p>
         <p class="archive-note">Archives OpenClassrooms visibles : {archives.length} projets secondaires documentant la progression web.</p>
       </section>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -172,6 +172,7 @@ button, a { outline-offset: 4px; }
 .project-card .tags { margin-top: auto; }
 .project-card:hover { transform: translateY(-4px); border-color: color-mix(in srgb, var(--accent), var(--line) 45%); box-shadow: var(--shadow-hover); }
 .project-card:hover img { transform: scale(1.045); filter: saturate(1.05) contrast(1.03); }
+.project-grid .project-card[hidden], .project-grid .project-card.is-filtered-out { display: none; }
 .tags { display: flex; flex-wrap: wrap; gap: 0.45rem; padding: 0; margin: 1rem 0; list-style: none; }
 .tags li { border: 1px solid color-mix(in srgb, var(--accent), #fff 55%); background: color-mix(in srgb, var(--accent), #fff 88%); border-radius: 999px; padding: 0.28rem 0.62rem; font-size: 0.78rem; font-weight: 750; }
 .text-link { color: var(--accent); font-weight: 900; text-decoration-thickness: 0.12em; text-underline-offset: 0.2em; }
@@ -181,7 +182,8 @@ button, a { outline-offset: 4px; }
 .filters button { border: 1px solid var(--line); background: #fff8ea; border-radius: 999px; padding: 0.72rem 1rem; color: #39443f; font-weight: 800; cursor: pointer; transition: transform 180ms ease, border-color 180ms ease, background 180ms ease, color 180ms ease, box-shadow 180ms ease; }
 .filters button:hover { transform: translateY(-1px); border-color: color-mix(in srgb, var(--accent), var(--line) 30%); box-shadow: 0 10px 25px rgba(38, 31, 21, 0.08); }
 .filters .is-active { border-color: var(--dark); background: var(--dark); color: #fff; box-shadow: inset 0 -3px 0 var(--accent); }
-.archive-note { color: var(--muted); }
+.archive-note, .project-empty { color: var(--muted); }
+.project-empty { width: var(--wrap); max-width: 100%; margin: 1rem auto 0; padding: 1rem; border: 1px dashed var(--line); border-radius: 1rem; background: #fff8ea; font-weight: 800; text-align: center; }
 
 /* skills */
 .skill-grid { display: grid; gap: 1rem; grid-template-columns: 1fr; }


### PR DESCRIPTION
### Motivation
- Corriger un filtrage non fiable des projets dans la grille catalogue pour que les boutons affichent seulement les cartes concernées et améliorent l’accessibilité.
- Mettre à jour les données du portfolio avec des dépôts publics récents, corriger les liens de démo obsolètes et ajouter les formations manquantes pour refléter le parcours.
- Prévenir tout changement binaire et documenter les visuels manquants en attente d’ajouts manuels.

### Description
- Réécrit le filtrage client-side pour cibler la grille catalogue `data-project-grid` ; ajout de `applyProjectFilter` dans `public/scripts/main.js` qui utilise `hidden` et `.is-filtered-out` et met à jour `is-active` et `aria-pressed` sur les boutons `data-filter`.
- Ajout d’un état vide accessible (`<p class="project-empty" data-project-empty aria-live="polite" hidden>`) et du CSS correspondant pour éviter des trous visuels incohérents; styles ajoutés dans `src/styles/global.css`.
- Actualisation des données dans `src/data/portfolioData.ts` : suppression de la démo obsolète de `bt-carrelage`, ajout des démos GitHub Pages pour `guide-investissement` et `recettes`, insertion factuelle de projets publics (`Locatech`, `LocMNS`, `BDSHOP`, `compressorImg`, `DomaAperoSite`) et regroupement des petits exercices en `exercices-progression`.
- Ajout des formations `OpenClassrooms` et `Metz Numeric School` dans `journey`, remplacement du compteur statique par `{projects.length}` et ajout des attributs `aria-pressed` initiaux dans `src/pages/index.astro`.
- Documenté les captures manquantes dans `TODO_ASSETS.md` sans créer/éditer de fichiers binaires; vérification que la workflow GitHub Pages est bien limité à `refs/heads/main` (gardes `if: github.ref == 'refs/heads/main'`).

### Testing
- Exécution de la build statique avec `npm run build`, qui s'est terminée avec succès and generated `dist/`.
- Vérification syntaxique du script avec `node --check public/scripts/main.js`, réussite.
- Test fonctionnel du filtrage via un mock DOM Node script (simulation des boutons `all`, `fullstack`, `data-bi`, `frontend`, `tools`, `archives`) confirmant que les cartes visibles correspondent exactement au filtre, réussite (`filter logic ok`).
- Vérification finale `git diff --numstat` avant commit confirmant que seuls fichiers texte ont été modifiés et qu’aucun binaire n’a été touché.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a490e7d4e44832c862f5d7326590078)