### PR TITLE
Corriger le workflow GitHub Pages : mettre à jour actions et désactiver Jekyll

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
@@ -33,7 +35,7 @@ jobs:
       - name: Build
         run: npm run build
       - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./dist
   deploy:
@@ -46,4 +48,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.nojekyll
+++ b/.nojekyll
@@ -1,0 +1,1 @@
+# Disables GitHub Pages Jekyll processing for this Astro project.

--- a/public/.nojekyll
+++ b/public/.nojekyll
@@ -1,0 +1,1 @@
+# Copied into dist/ so uploaded Pages artifacts also skip Jekyll.


### PR DESCRIPTION
### Motivation
- Éviter les erreurs liées à l’analyse Jekyll sur les fichiers Astro en empêchant GitHub Pages d’exécuter Jekyll sur l’artifact généré.
- Utiliser les versions Pages recommandées des actions GitHub pour supprimer les avertissements de runtime et rester compatible avec les APIs actuelles.

### Description
- Ajout de `.nojekyll` à la racine du dépôt et `public/.nojekyll` pour que l’artefact généré (`dist/`) contienne aussi le marqueur empêchant Jekyll.
- Mise à jour de `.github/workflows/pages.yml` pour insérer la step `actions/configure-pages@v5` et remplacer `actions/upload-pages-artifact@v3` et `actions/deploy-pages@v4` par leurs versions `@v5`.
- Le workflow conserve la configuration Node (`actions/setup-node@v6`) et la commande de build `npm run build` sans autres modifications.

### Testing
- Exécution de la construction avec `npm run build` qui s’est terminée avec succès et a généré `dist/` sans erreurs.
- Vérification que le fichier `.nojekyll` a bien été copié dans l’artefact avec la commande `test -f dist/.nojekyll`, qui a réussi.
- Aucune erreur automatisée supplémentaire détectée lors des commandes `npm ci` et `npm run build` lancées pendant la validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4918ca04f8832c8cf12d667a57b18c)