### PR TITLE
Modernize GitHub Pages workflow, add .nojekyll and update README deployment note

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v6
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
@@ -33,7 +35,7 @@ jobs:
       - name: Build
         run: npm run build
       - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./dist
   deploy:
@@ -46,4 +48,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ La configuration Astro est définie dans `astro.config.mjs` avec :
 
 Le workflow `.github/workflows/pages.yml` utilise Node 24, installe les dépendances avec `npm ci`, construit le site avec `npm run build`, puis publie le dossier `dist` via GitHub Pages.
 
+Dans **Settings → Pages**, la source de publication doit être réglée sur **GitHub Actions**. Si la source reste sur **Deploy from a branch**, GitHub Pages sert la racine du dépôt au lieu de l’artifact Astro généré, ce qui peut afficher une page 404 même lorsque le build réussit.
+
 ## Données portfolio
 
 Le contenu éditorial principal est centralisé dans `src/data/portfolioData.ts` : profil, liens, catégories, compétences, parcours, projets et projets vedettes.

--- a/public/.nojekyll
+++ b/public/.nojekyll
@@ -1,0 +1,1 @@
+# Copied into dist/ so uploaded Pages artifacts also skip Jekyll.


### PR DESCRIPTION
### Motivation

- Modernize and fix the GitHub Pages deployment to use the recommended configure/deploy actions and ensure the generated `dist` artifact is served instead of the repository root. 
- Prevent Jekyll processing of the site artifact so static files are served correctly and to avoid accidental 404s. 
- Document the required Pages publishing source in the README to avoid misconfiguration.

### Description

- Added a `Configure GitHub Pages` step using `actions/configure-pages@v6` to the `.github/workflows/pages.yml` workflow. 
- Bumped actions versions: `actions/upload-pages-artifact` to `v5` and `actions/deploy-pages` to `v5` in the Pages workflow. 
- Added `public/.nojekyll` (copied into `dist/`) so uploaded Pages artifacts skip Jekyll processing. 
- Updated `README.md` with a note instructing to set Pages source to `GitHub Actions` in repository Settings to ensure the artifact is served.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4918ca04f8832c8cf12d667a57b18c)