### PR TITLE
Fix mobile project section visibility

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -296,6 +296,8 @@ button, a { outline-offset: 4px; }
   .project-detail__header { padding-right: 0; }
   .project-detail__actions { justify-content: stretch; }
   .project-detail__actions .button { width: 100%; }
+  #projets[data-reveal],
+  #projets [data-reveal] { opacity: 1; transform: none; }
 }
 
 /* animations */


### PR DESCRIPTION
### Motivation
- On small screens the `#projets` section and its project cards stayed hidden because the global `[data-reveal]` animation leaves elements at `opacity: 0` before they are observed, so the mobile view needs an override to ensure the projects are visible.

### Description
- Add a small CSS override in `@media (max-width: 800px)` inside `src/styles/global.css` to set `#projets[data-reveal]` and `#projets [data-reveal]` to `opacity: 1` and `transform: none`, ensuring the section and its children are rendered on mobile.

### Testing
- Ran `npm run build` which completed successfully and `git diff --check` which returned no issues, both confirming the change builds cleanly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a492f64d758832c9d95dde366c394fb)