### PR TITLE
Polish portfolio UI rhythm and icons

### DIFF
--- a/src/components/ProjectDetails.astro
+++ b/src/components/ProjectDetails.astro
@@ -27,20 +27,20 @@ const hasLinks = Boolean(links.repo || links.demo || docs.length);
     </section>
 
     <div class="detail-grid detail-grid--story" aria-label="Contexte, problème, solution et impact">
-      {project.context && <section><h4><span class="icon-badge"><Icon name="document" /></span>Contexte</h4><p>{project.context}</p></section>}
-      {project.problem && <section><h4><span class="icon-badge"><Icon name="problem" /></span>Problème</h4><p>{project.problem}</p></section>}
-      {project.solution && <section><h4><span class="icon-badge"><Icon name="solution" /></span>Solution</h4><p>{project.solution}</p></section>}
-      {project.impact && <section><h4><span class="icon-badge"><Icon name="impact" /></span>Impact</h4><p>{project.impact}</p></section>}
+      {project.context && <section><h4><span class="icon-badge icon-badge--sm"><Icon name="document" /></span>Contexte</h4><p>{project.context}</p></section>}
+      {project.problem && <section><h4><span class="icon-badge icon-badge--sm"><Icon name="problem" /></span>Problème</h4><p>{project.problem}</p></section>}
+      {project.solution && <section><h4><span class="icon-badge icon-badge--sm"><Icon name="solution" /></span>Solution</h4><p>{project.solution}</p></section>}
+      {project.impact && <section><h4><span class="icon-badge icon-badge--sm"><Icon name="impact" /></span>Impact</h4><p>{project.impact}</p></section>}
     </div>
 
     {(hasDeliverables || hasDecisions) && (
       <div class="detail-grid detail-grid--lists">
-        {hasDeliverables && <section><h4><span class="icon-badge"><Icon name="deliverables" /></span>Livrables</h4><ul>{project.deliverables?.map((item) => <li>{item}</li>)}</ul></section>}
-        {hasDecisions && <section><h4><span class="icon-badge"><Icon name="decisions" /></span>Choix techniques</h4><ul>{project.decisions?.map((item) => <li>{item}</li>)}</ul></section>}
+        {hasDeliverables && <section><h4><span class="icon-badge icon-badge--sm"><Icon name="deliverables" /></span>Livrables</h4><ul>{project.deliverables?.map((item) => <li>{item}</li>)}</ul></section>}
+        {hasDecisions && <section><h4><span class="icon-badge icon-badge--sm"><Icon name="decisions" /></span>Choix techniques</h4><ul>{project.decisions?.map((item) => <li>{item}</li>)}</ul></section>}
       </div>
     )}
 
-    {project.learned && <section class="project-detail__learned"><h4><span class="icon-badge"><Icon name="learnings" /></span>Ce que j’ai appris</h4><p>{project.learned}</p></section>}
+    {project.learned && <section class="project-detail__learned"><h4><span class="icon-badge icon-badge--sm"><Icon name="learnings" /></span>Ce que j’ai appris</h4><p>{project.learned}</p></section>}
 
     {hasProof && (
       <section class="project-proof" aria-label="Ce projet démontre">
@@ -50,14 +50,14 @@ const hasLinks = Boolean(links.repo || links.demo || docs.length);
         </div>
         <div class="project-proof__grid">
           {project.highlights.length > 0 && <article><h5>Points clés</h5><ul>{project.highlights.map((item) => <li>{item}</li>)}</ul></article>}
-          {project.skills.length > 0 && <article><h5><span class="icon-badge"><Icon name="stack" /></span>Compétences mobilisées</h5><ul>{project.skills.map((item) => <li>{item}</li>)}</ul></article>}
-          {project.metrics.length > 0 && <article><h5><span class="icon-badge"><Icon name="metrics" /></span>Repères techniques</h5><ul>{project.metrics.map((item) => <li>{item}</li>)}</ul></article>}
+          {project.skills.length > 0 && <article><h5><span class="icon-badge icon-badge--sm"><Icon name="stack" /></span>Compétences mobilisées</h5><ul>{project.skills.map((item) => <li>{item}</li>)}</ul></article>}
+          {project.metrics.length > 0 && <article><h5><span class="icon-badge icon-badge--sm"><Icon name="metrics" /></span>Repères techniques</h5><ul>{project.metrics.map((item) => <li>{item}</li>)}</ul></article>}
         </div>
       </section>
     )}
 
     <section class="project-detail__stack" aria-label="Stack technique">
-      <h4><span class="icon-badge"><Icon name="stack" /></span>Stack technique</h4>
+      <h4><span class="icon-badge icon-badge--sm"><Icon name="stack" /></span>Stack technique</h4>
       <ul class="tags">{project.stack.map((item) => <li>{item}</li>)}</ul>
     </section>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -32,10 +32,10 @@ const archives = projects.filter((p) => p.category === 'archives');
           <h1 id="hero-title">{profile.name}<span>{profile.title}</span></h1>
           <p class="hero__lead">{profile.value}</p>
           <div class="hero__chips" aria-label="Repères portfolio">
-            <span><span class="icon-badge"><Icon name="projects" /></span>{projects.length} projets</span>
-            <span><span class="icon-badge"><Icon name="case-studies" /></span>5 case studies</span>
-            <span><span class="icon-badge"><Icon name="fullstack" /></span>Fullstack + Data</span>
-            <span><span class="icon-badge"><Icon name="github-pages" /></span>Astro / GitHub Pages</span>
+            <span><span class="icon-badge icon-badge--sm"><Icon name="projects" /></span>{projects.length} projets</span>
+            <span><span class="icon-badge icon-badge--sm"><Icon name="case-studies" /></span>5 case studies</span>
+            <span><span class="icon-badge icon-badge--sm"><Icon name="fullstack" /></span>Fullstack + Data</span>
+            <span><span class="icon-badge icon-badge--sm"><Icon name="github-pages" /></span>Astro / GitHub Pages</span>
           </div>
           <div class="hero__actions">
             <a class="button" href="#case-studies">Voir les projets clés</a>
@@ -51,7 +51,7 @@ const archives = projects.filter((p) => p.category === 'archives');
             </div>
           </div>
           <ul>
-            {capabilities.map((cap) => <li><b><span class="icon-badge"><Icon name={cap.icon} /></span>{cap.title}</b><span>{cap.text}</span></li>)}
+            {capabilities.map((cap) => <li><b><span class="icon-badge icon-badge--lg"><Icon name={cap.icon} /></span>{cap.title}</b><span>{cap.text}</span></li>)}
           </ul>
         </aside>
       </section>
@@ -71,7 +71,7 @@ const archives = projects.filter((p) => p.category === 'archives');
 
       <section id="competences" class="section split" data-reveal>
         <SectionHeader eyebrow="Compétences" title="Un socle fullstack complété par la donnée" />
-        <div class="skill-grid">{skills.map((group) => <article data-reveal><h3><span class="icon-badge"><Icon name={group.icon} /></span>{group.group}</h3><ul>{group.items.map((item) => <li>{item}</li>)}</ul></article>)}</div>
+        <div class="skill-grid">{skills.map((group) => <article data-reveal><h3><span class="icon-badge icon-badge--md"><Icon name={group.icon} /></span>{group.group}</h3><ul>{group.items.map((item) => <li>{item}</li>)}</ul></article>)}</div>
       </section>
 
       <section id="parcours" class="section" data-reveal>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -110,7 +110,7 @@ button, a { outline-offset: 4px; }
 .hero h1 span { display: block; max-width: 55rem; margin-top: 1rem; font-size: clamp(1.2rem, 2.5vw, 2rem); line-height: 1.2; letter-spacing: -0.02em; }
 .hero__lead { max-width: 56rem; color: #39443f; font-size: clamp(1.2rem, 2vw, 1.7rem); }
 .hero__chips { display: flex; flex-wrap: wrap; gap: 0.65rem; margin: 1.4rem 0; }
-.hero__chips span {
+.hero__chips > span {
   display: inline-flex;
   align-items: center;
   gap: 0.6rem;
@@ -129,19 +129,19 @@ button, a { outline-offset: 4px; }
   border: 1px solid var(--line);
   box-shadow: var(--shadow-soft);
 }
-.hero__focus { border-radius: var(--radius-lg); padding: clamp(1.2rem, 3vw, 1.8rem); }
+.hero__focus { border-radius: var(--radius-lg); padding: clamp(1.45rem, 3vw, 2.15rem); }
 .hero__focus-head { display: grid; grid-template-columns: auto 1fr; gap: 1rem; align-items: start; }
 .hero__focus-head > span { width: 0.85rem; height: 3.2rem; border-radius: 999px; background: linear-gradient(var(--accent), #d98b35); box-shadow: 0 0 0 8px color-mix(in srgb, var(--accent), transparent 86%); }
 .hero__focus strong { display: block; font-size: 1.35rem; letter-spacing: -0.03em; }
 .hero__focus p { margin: 0.25rem 0 0; color: var(--muted); }
-.hero__focus ul { display: grid; grid-template-columns: 1fr 1fr; gap: 0.8rem; padding: 0; margin: 1.3rem 0 0; list-style: none; }
-.hero__focus li { padding: 0.9rem; border: 1px solid color-mix(in srgb, var(--line), #fff 40%); border-radius: 1rem; background: rgba(255,255,255,0.38); transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease; }
+.hero__focus ul { display: grid; grid-template-columns: 1fr 1fr; gap: clamp(0.9rem, 1.6vw, 1.15rem); padding: 0; margin: 1.6rem 0 0; list-style: none; }
+.hero__focus li { padding: clamp(1.05rem, 2vw, 1.3rem); border: 1px solid color-mix(in srgb, var(--line), #fff 40%); border-radius: 1.15rem; background: rgba(255,255,255,0.42); transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease, background 180ms ease; }
 .hero__focus li:hover { transform: translateY(-2px); border-color: color-mix(in srgb, var(--accent), var(--line) 44%); box-shadow: 0 18px 34px rgba(38, 31, 21, 0.09); }
-.hero__focus li span { display: block; color: var(--muted); font-size: 0.9rem; }
+.hero__focus li span { display: block; margin-top: 0.55rem; color: var(--muted); font-size: 0.94rem; line-height: 1.58; }
 
 /* sections */
-.section { padding: clamp(3rem, 7vw, 6rem) clamp(1rem, 4vw, 4rem); }
-.section-header { max-width: 58rem; margin-bottom: 2rem; }
+.section { padding: clamp(4rem, 8vw, 7.5rem) clamp(1rem, 4vw, 4rem); }
+.section-header { max-width: 62rem; margin-bottom: clamp(2.1rem, 4vw, 3.25rem); }
 .section-header h2 { margin: 0.2rem 0; font-size: clamp(2rem, 5vw, 4.5rem); line-height: 1; letter-spacing: -0.05em; }
 .button {
   display: inline-flex;
@@ -167,7 +167,7 @@ button, a { outline-offset: 4px; }
   width: var(--wrap);
   max-width: 100%;
   margin-inline: auto;
-  gap: clamp(1rem, 2vw, 1.35rem);
+  gap: clamp(1.35rem, 2.4vw, 2.15rem);
   grid-template-columns: 1fr;
 }
 .project-card {
@@ -182,24 +182,24 @@ button, a { outline-offset: 4px; }
 .project-card::before { content: ""; height: 5px; background: linear-gradient(90deg, var(--accent), color-mix(in srgb, var(--accent), #fff 52%)); }
 .project-card__media { overflow: hidden; background: #ddd6ca; }
 .project-card img { width: 100%; aspect-ratio: 16 / 9; object-fit: cover; transition: transform 450ms ease, filter 220ms ease; }
-.project-card__body { display: flex; flex: 1; flex-direction: column; padding: 1.15rem; }
+.project-card__body { display: flex; flex: 1; flex-direction: column; gap: 1rem; padding: clamp(1.35rem, 2vw, 1.75rem); }
 .project-card__meta { display: flex; justify-content: space-between; gap: 0.5rem; color: var(--muted); font-size: 0.74rem; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; }
-.project-card h3 { margin: 0.85rem 0 0.45rem; font-size: 1.35rem; line-height: 1.1; letter-spacing: -0.03em; }
-.project-card p { margin: 0; color: #43504a; }
-.project-card .tags { margin-top: auto; }
+.project-card h3 { margin: 0; font-size: clamp(1.35rem, 2vw, 1.55rem); line-height: 1.08; letter-spacing: -0.035em; }
+.project-card p { margin: 0; color: #43504a; line-height: 1.65; }
+.project-card .tags { margin-top: auto; padding-top: 0.3rem; }
 .project-card:hover { transform: translateY(-4px); border-color: color-mix(in srgb, var(--accent), var(--line) 45%); box-shadow: var(--shadow-hover); }
 .project-card:hover img { transform: scale(1.045); filter: saturate(1.05) contrast(1.03); }
 .project-grid .project-card[hidden], .project-grid .project-card.is-filtered-out { display: none; }
-.tags { display: flex; flex-wrap: wrap; gap: 0.45rem; padding: 0; margin: 1rem 0; list-style: none; }
-.tags li { border: 1px solid color-mix(in srgb, var(--accent), #fff 55%); background: color-mix(in srgb, var(--accent), #fff 88%); border-radius: 999px; padding: 0.28rem 0.62rem; font-size: 0.78rem; font-weight: 750; }
+.tags { display: flex; flex-wrap: wrap; gap: 0.55rem; padding: 0; margin: 1rem 0; list-style: none; }
+.tags li { border: 1px solid color-mix(in srgb, var(--accent), #fff 55%); background: color-mix(in srgb, var(--accent), #fff 90%); border-radius: 999px; padding: 0.36rem 0.72rem; font-size: 0.78rem; font-weight: 750; line-height: 1.1; }
 .text-link { color: var(--accent); font-weight: 900; text-decoration-thickness: 0.12em; text-underline-offset: 0.2em; }
-.project-card__actions { margin-top: 0.15rem; }
-.project-card__actions .button { min-height: 2.85rem; padding-inline: 1rem; }
+.project-card__actions { margin-top: 0.55rem; padding-top: 0.2rem; gap: 0.65rem; }
+.project-card__actions .button { min-height: 3rem; padding-inline: 1.05rem; }
 .project-card__actions .text-link {
   border: 1px solid color-mix(in srgb, var(--accent), var(--line) 58%);
   border-radius: 999px;
   background: color-mix(in srgb, var(--accent), transparent 93%);
-  padding: 0.62rem 0.82rem;
+  min-height: 3rem; padding: 0.66rem 0.9rem;
   text-decoration: none;
   transition: transform 180ms ease, background 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
 }
@@ -210,17 +210,32 @@ button, a { outline-offset: 4px; }
   box-shadow: 0 10px 24px color-mix(in srgb, var(--accent), transparent 88%);
 }
 
+/* premium rhythm refinements */
+.project-card__media { margin: clamp(0.55rem, 1.2vw, 0.8rem) clamp(0.55rem, 1.2vw, 0.8rem) 0; border-radius: calc(var(--radius-md) - 0.35rem); }
+.project-card__meta + h3 { margin-top: 0.08rem; }
+.project-card__actions .text-link,
+.project-card__actions .button { white-space: nowrap; }
+.project-card__actions .icon-wrap { --icon-size: 1.12rem; }
+.filters button { min-height: 2.9rem; padding-inline: 1rem; }
+.hero__focus li b { width: 100%; line-height: 1.18; }
+.hero__focus li:hover { background: rgba(255,255,255,0.58); }
+
+.icon-badge--sm { --icon-badge-size: 2.05rem; --icon-in-badge-size: 1.05rem; --icon-badge-radius: 0.78rem; }
+.icon-badge--md { --icon-badge-size: 2.55rem; --icon-in-badge-size: 1.32rem; --icon-badge-radius: 0.92rem; }
+.icon-badge--lg { --icon-badge-size: clamp(2.4rem, 4vw, 2.7rem); --icon-in-badge-size: clamp(1.25rem, 2vw, 1.45rem); --icon-badge-radius: 0.95rem; }
+.icon-badge--hero { --icon-badge-size: 3rem; --icon-in-badge-size: 1.55rem; --icon-badge-radius: 1rem; }
+
 /* filters */
-.filters { display: flex; flex-wrap: wrap; gap: 0.55rem; margin-bottom: 1.5rem; }
-.filters button { border: 1px solid var(--line); background: #fff8ea; border-radius: 999px; padding: 0.66rem 0.95rem; color: #39443f; font-weight: 800; cursor: pointer; transition: transform 180ms ease, border-color 180ms ease, background 180ms ease, color 180ms ease, box-shadow 180ms ease; }
+.filters { display: flex; flex-wrap: wrap; gap: 0.75rem; width: var(--wrap); max-width: 100%; margin: 0 auto 2.1rem; }
+.filters button { border: 1px solid var(--line); background: #fff8ea; border-radius: 999px; padding: 0.66rem 1rem; color: #39443f; font-weight: 800; cursor: pointer; transition: transform 180ms ease, border-color 180ms ease, background 180ms ease, color 180ms ease, box-shadow 180ms ease; }
 .filters button:hover { transform: translateY(-1px); border-color: color-mix(in srgb, var(--accent), var(--line) 30%); box-shadow: 0 10px 25px rgba(38, 31, 21, 0.08); }
 .filters .is-active { border-color: var(--dark); background: var(--dark); color: #fff; box-shadow: inset 0 -3px 0 var(--accent); }
 .archive-note, .project-empty { color: var(--muted); }
 .project-empty { width: var(--wrap); max-width: 100%; margin: 1rem auto 0; padding: 1rem; border: 1px dashed var(--line); border-radius: 1rem; background: #fff8ea; font-weight: 800; text-align: center; }
 
 /* skills */
-.skill-grid { display: grid; gap: 1rem; grid-template-columns: 1fr; }
-.skill-grid article { padding: 1.25rem; border-radius: 1rem; border-top: 4px solid color-mix(in srgb, var(--accent), #d98b35 35%); transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease; }
+.skill-grid { display: grid; width: var(--wrap); max-width: 100%; margin-inline: auto; gap: clamp(1.1rem, 2vw, 1.65rem); grid-template-columns: 1fr; }
+.skill-grid article { padding: clamp(1.35rem, 2vw, 1.7rem); border-radius: 1.1rem; border-top: 4px solid color-mix(in srgb, var(--accent), #d98b35 35%); transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease; }
 .skill-grid article:hover { transform: translateY(-3px); border-color: color-mix(in srgb, var(--accent), var(--line) 45%); box-shadow: var(--shadow-card); }
 .skill-grid h3 { margin: 0 0 0.8rem; padding-bottom: 0.75rem; border-bottom: 1px solid var(--line); letter-spacing: -0.02em; line-height: 1.15; }
 .skill-grid ul { display: flex; flex-wrap: wrap; gap: 0.45rem; padding: 0; margin: 0; list-style: none; }
@@ -308,7 +323,7 @@ button, a { outline-offset: 4px; }
   html { scroll-behavior: auto; }
   *, *::before, *::after { animation-duration: 0.001ms !important; animation-iteration-count: 1 !important; scroll-behavior: auto !important; transition-duration: 0.001ms !important; }
   [data-reveal] { opacity: 1; transform: none; }
-  .project-card:hover, .button:hover, .filters button:hover { transform: none; }
+  .project-card:hover, .button:hover, .filters button:hover, .hero__focus li:hover, .skill-grid article:hover, .project-card__actions .text-link:hover { transform: none; }
   .project-card:hover img { transform: none; }
 }
 
@@ -320,7 +335,7 @@ button, a { outline-offset: 4px; }
   flex: 0 0 auto;
   color: var(--icon-accent, currentColor);
   line-height: 0;
-  vertical-align: -0.12em;
+  vertical-align: middle;
 }
 .icon {
   width: 100%;
@@ -342,8 +357,8 @@ button, a { outline-offset: 4px; }
   color: var(--icon-accent, var(--accent));
   box-shadow: 0 10px 24px color-mix(in srgb, var(--icon-accent, var(--accent)), transparent 88%), inset 0 1px 0 rgba(255,255,255,0.7);
 }
-.icon-badge .icon-wrap { --icon-size: var(--icon-in-badge-size, 1.15rem); }
-.icon-link, .nav-link, .button, .filters button, .hero__chips span, .hero__focus li b, .skill-grid h3, .project-card__actions a, .project-card__actions button, .project-detail__actions a, .detail-grid h4, .project-detail__learned h4, .project-detail__stack h4, .project-proof h5 {
+.icon-badge .icon-wrap { width: var(--icon-in-badge-size, 1.15rem); height: var(--icon-in-badge-size, 1.15rem); line-height: 0; vertical-align: initial; }
+.icon-link, .nav-link, .button, .filters button, .hero__chips > span, .hero__focus li b, .skill-grid h3, .project-card__actions a, .project-card__actions button, .project-detail__actions a, .detail-grid h4, .project-detail__learned h4, .project-detail__stack h4, .project-proof h5 {
   display: inline-flex;
   align-items: center;
   gap: var(--icon-gap, 0.5rem);
@@ -353,9 +368,9 @@ button, a { outline-offset: 4px; }
 .button { --icon-size: 1.18rem; --icon-gap: 0.55rem; }
 .button--ghost { --icon-accent: var(--accent); }
 .filters button { --icon-size: 1.2rem; --icon-gap: 0.55rem; }
-.hero__chips span { --icon-badge-size: 1.95rem; --icon-in-badge-size: 1rem; --icon-gap: 0.6rem; }
-.hero__focus li b { --icon-badge-size: 2.25rem; --icon-in-badge-size: 1.18rem; --icon-gap: 0.65rem; }
-.skill-grid h3 { --icon-badge-size: 2.65rem; --icon-in-badge-size: 1.35rem; --icon-gap: 0.75rem; }
+.hero__chips > span { --icon-gap: 0.6rem; }
+.hero__focus li b { --icon-gap: 0.78rem; }
+.skill-grid h3 { --icon-gap: 0.78rem; }
 .project-card__actions { --icon-size: 1.15rem; }
 .detail-grid h4, .project-detail__learned h4, .project-detail__stack h4, .project-proof h5 { --icon-badge-size: 2rem; --icon-in-badge-size: 1rem; --icon-gap: 0.55rem; }
 .site-footer address .icon-link { text-decoration: none; color: var(--muted); font-weight: 800; }


### PR DESCRIPTION
### Motivation
- Improve overall visual rhythm and breathing space across the portfolio to give a more premium, readable presentation. 
- Make project cards feel more like showcases by increasing padding, vertical spacing and stabilizing action buttons.  
- Treat icons as purposeful visual anchors by fixing centering, sizing and badge treatment rather than leaving them as small utilitarian pictograms.  

### Description
- Adjusted global spacing and grid gaps in `src/styles/global.css` to increase section padding, grid gaps (`.featured-grid`, `.project-grid`, `.skill-grid`) and section header spacing.  
- Reworked project card layout in `src/styles/global.css` to add internal `gap`, larger `padding` for `.project-card__body`, more breathing for media (`.project-card__media`), clearer tag separation (`.tags`) and more comfortable action spacing/height (`.project-card__actions`, `.button`, `.text-link`).  
- Redesigned the icon system in `src/styles/global.css` by neutralizing `.icon-wrap`, enforcing `inline-grid` centering for `.icon-badge`, and adding badge size variants `icon-badge--sm`, `icon-badge--md`, `icon-badge--lg`, `icon-badge--hero` with explicit `--icon-in-badge-size` values.  
- Applied badge variants in templates: updated `src/pages/index.astro` to use `icon-badge--sm` for hero chips, `icon-badge--lg` for Focus 2026 capabilities and `icon-badge--md` for skill group headings, and updated `src/components/ProjectDetails.astro` to use `icon-badge--sm` in detail panels so icon sizing/centering is consistent.  
- Improved Focus 2026 items with larger padding, improved `line-height` and clearer typographic hierarchy in `src/styles/global.css`, and softened micro-interactions (subtle hover translation) while respecting `prefers-reduced-motion`.  

### Testing
- Ran `npm ci` successfully to install dependencies.  
- Built the site with `ASTRO_TELEMETRY_DISABLED=1 npm run build` which completed successfully and produced the static output (3 pages built).  
- Ran quick source checks with `rg -n 'href="/|src="/' src` and `rg -n "manifest.json|React App|Create React App|logo192|logo512" src public` which returned no problematic occurrences.  
- Verified modified files: `src/styles/global.css`, `src/pages/index.astro`, and `src/components/ProjectDetails.astro`, and confirmed the build and reduced-motion behaviors functioned as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a493240c2f0832c9437e2ad5c789df5)