### PR TITLE
Improve portfolio project storytelling

### DIFF
--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -22,6 +22,11 @@ const applyProjectFilter = (filter) => {
     if (shouldShow) visibleCount += 1;
   });
 
+  projectGrid?.querySelectorAll('[data-project-group]').forEach((group) => {
+    const visibleCards = group.querySelectorAll('[data-project-card]:not([hidden])').length;
+    group.hidden = visibleCards === 0;
+  });
+
   if (emptyState) {
     emptyState.hidden = visibleCount > 0;
   }

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -1,5 +1,6 @@
 ---
 import Icon from './Icon.astro';
+import ProjectVisual from './ProjectVisual.astro';
 import type { Project } from '../data/portfolioData';
 
 const { project, index = 0 } = Astro.props as { project: Project; index?: number };
@@ -7,7 +8,11 @@ const links = project.links ?? {};
 ---
 <article class:list={["project-card", project.featured && "is-featured"]} data-project-card data-reveal data-category={project.category} style={`--accent:${project.accent};--reveal-delay:${Math.min(index % 4, 3) * 80}ms`}>
   <div class="project-card__media">
-    <img src={project.image.src} alt={project.imageAlt} loading={index < 3 ? 'eager' : 'lazy'} decoding="async" />
+    {project.visual ? (
+      <ProjectVisual visual={project.visual} title={project.title} />
+    ) : (
+      <img src={project.image.src} alt={project.imageAlt} loading={index < 3 ? 'eager' : 'lazy'} decoding="async" />
+    )}
   </div>
   <div class="project-card__body">
     <div class="project-card__meta">

--- a/src/components/ProjectVisual.astro
+++ b/src/components/ProjectVisual.astro
@@ -1,0 +1,39 @@
+---
+import type { ProjectVisual as ProjectVisualType } from '../data/portfolioData';
+
+const { visual, title } = Astro.props as { visual: ProjectVisualType; title: string };
+const metrics = visual.metrics?.slice(0, 3) ?? [];
+---
+<div class:list={["project-visual", `project-visual--${visual.kind}`]} role="img" aria-label={`Visuel CSS du projet ${title}`}>
+  <div class="project-visual__chrome"><span></span><span></span><span></span></div>
+  <div class="project-visual__content">
+    <p>{visual.eyebrow ?? visual.kind}</p>
+    <strong>{visual.title ?? title}</strong>
+
+    {visual.kind === 'sql' && (
+      <div class="visual-sql" aria-hidden="true">
+        <code>SELECT region, COUNT(*)</code>
+        <code>FROM contrats</code>
+        <code>GROUP BY region;</code>
+      </div>
+    )}
+
+    {visual.kind === 'api' && (
+      <div class="visual-api" aria-hidden="true">
+        <span>Angular</span><i></i><span>REST API</span><i></i><span>SQL / NoSQL</span>
+      </div>
+    )}
+
+    {['dashboard', 'data', 'app', 'tool', 'document'].includes(visual.kind) && (
+      <div class="visual-panels" aria-hidden="true">
+        <span></span><span></span><span></span><span></span>
+      </div>
+    )}
+
+    {metrics.length > 0 && (
+      <ul>
+        {metrics.map((metric) => <li>{metric}</li>)}
+      </ul>
+    )}
+  </div>
+</div>

--- a/src/data/portfolioData.ts
+++ b/src/data/portfolioData.ts
@@ -7,6 +7,13 @@ export type ProjectLink = {
   repo?: string;
 };
 
+export type ProjectVisual = {
+  kind: 'dashboard' | 'data' | 'sql' | 'app' | 'api' | 'document' | 'tool';
+  eyebrow?: string;
+  title?: string;
+  metrics?: string[];
+};
+
 export type Project = {
   id: string;
   title: string;
@@ -18,6 +25,7 @@ export type Project = {
   role: string;
   image: ImageMetadata;
   imageAlt: string;
+  visual?: ProjectVisual;
   accent: string;
   stack: string[];
   skills: string[];
@@ -98,12 +106,12 @@ export const journey = [
   { period: 'Parcours terrain', title: 'Culture technique et usage réel', text: 'Expérience pratique issue de domaines techniques, utile pour comprendre les contraintes concrètes et les besoins opérationnels.' }
 ];
 
-const imageFallback = cardImage;
+const placeholderImage = cardImage;
 
 export const projects: Project[] = [
   {
     id: 'jlh-autopam', title: 'JLH AutoPam', shortTitle: 'Garage connecté', category: 'fullstack', featured: true,
-    status: 'En cours / projet vitrine', period: '2026', role: 'Développeur fullstack', image: imageFallback, imageAlt: 'Visuel temporaire pour le dashboard JLH AutoPam', accent: '#2d7f82',
+    status: 'En cours / projet vitrine', period: '2026', role: 'Développeur fullstack', image: placeholderImage, imageAlt: 'Interface métier JLH AutoPam générée en CSS', visual: { kind: 'app', eyebrow: 'Garage connecté', title: 'Demandes · devis · rendez-vous', metrics: ['Espace client', 'Back-office', 'JWT + rôles'] }, accent: '#2d7f82',
     stack: ['Angular 20', 'Angular SSR', 'TypeScript', 'SCSS', 'Spring Boot 3.5', 'Java 17', 'PostgreSQL', 'JWT', 'Docker'],
     skills: ['Architecture front/back', 'API REST', 'Authentification', 'Rôles', 'Workflow métier'],
     summary: 'Application métier complète pour un garage automobile, avec espace client, administration, demandes, devis et rendez-vous.',
@@ -120,7 +128,7 @@ export const projects: Project[] = [
   },
   {
     id: 'bottleneck', title: 'BottleNeck — nettoyage et analyse des stocks', shortTitle: 'Stocks & CA', category: 'data-bi', featured: true,
-    status: 'Projet data analyst', period: 'Formation data', role: 'Data analyst junior', image: imageFallback, imageAlt: 'Visuel temporaire pour le notebook BottleNeck', accent: '#b66b33',
+    status: 'Projet data analyst', period: 'Formation data', role: 'Data analyst junior', image: placeholderImage, imageAlt: 'Tableau de contrôle data BottleNeck généré en CSS', visual: { kind: 'data', eyebrow: 'Data quality', title: 'ERP + web + stocks', metrics: ['Jointures contrôlées', 'CA produit', 'Outliers prix'] }, accent: '#b66b33',
     stack: ['Python', 'pandas', 'numpy', 'Jupyter Notebook', 'Excel', 'matplotlib', 'seaborn'], skills: ['Nettoyage', 'Jointures', 'Outliers', 'Analyse commerciale'],
     summary: 'Consolidation de fichiers ERP, web et liaison pour analyser les produits, ventes, stocks et anomalies.',
     context: 'Analyse d’un catalogue de vins à partir de sources ERP, web et fichier de liaison, avec un besoin de fiabiliser les rapprochements avant toute lecture commerciale.',
@@ -135,7 +143,7 @@ export const projects: Project[] = [
   },
   {
     id: 'assurance-data', title: 'Assurance habitation — SQL et modélisation', shortTitle: 'SQL assurance', category: 'data-bi', featured: true,
-    status: 'Projet data / SQL', period: 'Formation data', role: 'Concepteur base de données', image: imageFallback, imageAlt: 'Visuel temporaire pour le schéma SQL assurance habitation', accent: '#235a70',
+    status: 'Projet data / SQL', period: 'Formation data', role: 'Concepteur base de données', image: placeholderImage, imageAlt: 'Schéma relationnel assurance habitation généré en CSS', visual: { kind: 'sql', eyebrow: 'PostgreSQL', title: 'Contrats · communes · régions', metrics: ['Modèle normalisé', 'Imports CSV', 'Requêtes métier'] }, accent: '#235a70',
     stack: ['SQL', 'PostgreSQL', 'CSV', 'Modélisation relationnelle'], skills: ['Normalisation', 'Import CSV', 'Contrôle qualité', 'Analyse géographique'],
     summary: 'Transformation de fichiers CSV bruts en base relationnelle exploitable pour analyser des contrats d’assurance habitation.',
     context: 'Projet SQL construit à partir de CSV bruts liés à l’assurance habitation, avec un enjeu de normalisation géographique et de requêtes métier fiables.',
@@ -149,8 +157,8 @@ export const projects: Project[] = [
     links: { repo: 'https://github.com/steve57000/assurance_data' }
   },
   {
-    id: 'rgpd-dev-immediat', title: "RGPD Dev'Immédiat", shortTitle: 'Anonymisation CRM', category: 'data-bi', featured: true,
-    status: 'Livrable data', period: 'Formation data', role: 'Data analyst junior', image: imageFallback, imageAlt: 'Visuel temporaire pour le dataset anonymisé RGPD', accent: '#56616f',
+    id: 'rgpd-dev-immediat', title: "RGPD Dev'Immédiat", shortTitle: 'Anonymisation CRM', category: 'data-bi', featured: false,
+    status: 'Livrable data', period: 'Formation data', role: 'Data analyst junior', image: placeholderImage, imageAlt: 'Document de conformité RGPD généré en CSS', visual: { kind: 'document', eyebrow: 'Privacy by design', title: 'Dataset anonymisé et documenté', metrics: ['Minimisation', 'Quasi-identifiants', 'Traçabilité'] }, accent: '#56616f',
     stack: ['CSV', 'Analyse de données', 'Documentation RGPD', 'Minimisation', 'Anonymisation'], skills: ['RGPD', 'Quasi-identifiants', 'Documentation', 'Qualité données'],
     summary: "Mise en conformité RGPD d'un CRM en conservant un dataset exploitable pour l'analyse.",
     context: 'Travail sur un jeu de données CRM à partager ou analyser en limitant l’exposition des données personnelles.',
@@ -164,8 +172,8 @@ export const projects: Project[] = [
     links: {}
   },
   {
-    id: 'sportdatapulse', title: 'SportDataPulse', shortTitle: 'Football BI', category: 'data-bi', featured: true,
-    status: 'Projet SQL / BI', period: 'Formation data', role: 'Data analyst SQL', image: imageFallback, imageAlt: 'Visuel temporaire pour les requêtes SQL SportDataPulse', accent: '#1d6f56',
+    id: 'sportdatapulse', title: 'SportDataPulse', shortTitle: 'Football BI', category: 'data-bi', featured: false,
+    status: 'Projet SQL / BI', period: 'Formation data', role: 'Data analyst SQL', image: placeholderImage, imageAlt: 'Dashboard football BI généré en CSS', visual: { kind: 'dashboard', eyebrow: 'Football BI', title: 'KPI joueurs · équipes · shortlist', metrics: ['SQL analytique', 'Indicateurs', 'Décisionnel'] }, accent: '#1d6f56',
     stack: ['PostgreSQL', 'SQL', 'Data analysis', 'Présentation métier'], skills: ['Indicateurs', 'Shortlist', 'Requêtes métier', 'Décisionnel'],
     summary: 'Base sportive et analyses SQL autour des performances football pour éclairer recrutement et suivi joueurs/équipes.',
     context: 'Projet BI football centré sur la transformation de données sportives en indicateurs lisibles pour un besoin de suivi et de recrutement.',
@@ -179,16 +187,16 @@ export const projects: Project[] = [
     links: {}
   },
   {
-    id: 'guide-investissement', title: 'Guide Investissement', shortTitle: 'Outils finance perso', category: 'tools', featured: false, status: 'Projet personnel', period: '2026', role: 'Développeur front', image: imageFallback, imageAlt: 'Visuel temporaire pour le dashboard Guide Investissement', accent: '#8a6b2f',
+    id: 'guide-investissement', title: 'Guide Investissement', shortTitle: 'Outils finance perso', category: 'tools', featured: true, status: 'Projet personnel', period: '2026', role: 'Développeur front', image: placeholderImage, imageAlt: 'Dashboard privacy-first Guide Investissement généré en CSS', visual: { kind: 'dashboard', eyebrow: 'Outil publié', title: 'Journal local · dashboard · contenus', metrics: ['Démo GitHub Pages', 'Privacy-first', 'Astro statique'] }, accent: '#8a6b2f',
     stack: ['Astro', 'TypeScript', 'localStorage', 'GitHub Pages'], skills: ['SEO', 'Privacy-first', 'Scripts de vérification'], summary: 'Site éducatif statique avec outils interactifs, journal et dashboard personnel stockés localement.', context: 'Projet personnel orienté pédagogie financière et suivi local, sans collecte serveur ni compte utilisateur.', problem: 'Proposer un outil simple et privé pour suivre une démarche d’investissement personnelle.', solution: 'Architecture statique, données locales, contenus pédagogiques et contrôles automatisés.', deliverables: ['Site statique éducatif', 'Journal local', 'Dashboard personnel', 'Scripts de vérification'], decisions: ['Stocker les données dans le navigateur pour préserver la confidentialité', 'Favoriser des pages statiques compatibles GitHub Pages', 'Documenter les contrôles utiles avant publication'], learned: 'Structuration d’un outil privacy-first avec une attention SEO, contenu et vérification automatisée.', impact: 'Démontre une approche produit, SEO et respect de la confidentialité.', highlights: ['Journal', 'Dashboard', 'localStorage', 'SEO'], metrics: ['GitHub Pages', 'Privacy-first'], links: { repo: 'https://github.com/steve57000/guide-investissement', demo: 'https://steve57000.github.io/guide-investissement/' }
   },
   {
-    id: 'recettes', title: 'Recettes', shortTitle: 'Livre de cuisine', category: 'tools', featured: false, status: 'Projet personnel', period: '2026', role: 'Développeur front', image: imageFallback, imageAlt: 'Visuel temporaire pour l’application Recettes', accent: '#a65a42', stack: ['JavaScript', 'HTML/CSS', 'localStorage', 'JSON'], skills: ['CRUD', 'Export/import', 'UX utilitaire'], summary: 'Application statique de recettes avec portions dynamiques, liste de courses et sauvegarde JSON.', context: 'Projet personnel conçu pour gérer des recettes du quotidien dans une application simple, portable et sans backend obligatoire.', problem: 'Organiser des recettes et courses sans backend obligatoire.', solution: 'CRUD local, calcul des portions, export/import et synchronisation JSON possible.', deliverables: ['Catalogue de recettes', 'Calcul des portions', 'Liste de courses', 'Export/import JSON'], decisions: ['Garder une application statique pour faciliter l’hébergement', 'Utiliser le stockage local et un format JSON lisible', 'Prioriser les actions utiles en cuisine plutôt qu’une interface complexe'], learned: 'Conception d’un outil utilitaire centré sur les usages réels : données locales, édition rapide et portabilité.', impact: 'Projet utile, concret et orienté usage quotidien.', highlights: ['CRUD', 'Portions dynamiques', 'Liste de courses', 'JSON'], metrics: ['localStorage', 'Application statique'], links: { repo: 'https://github.com/steve57000/recettes', demo: 'https://steve57000.github.io/recettes/' }
+    id: 'recettes', title: 'Recettes', shortTitle: 'Livre de cuisine', category: 'tools', featured: false, status: 'Projet personnel', period: '2026', role: 'Développeur front', image: placeholderImage, imageAlt: 'Mockup applicatif Recettes généré en CSS', visual: { kind: 'tool', eyebrow: 'Outil quotidien', title: 'Recettes · portions · courses', metrics: ['CRUD local', 'Export JSON', 'Sans backend'] }, accent: '#a65a42', stack: ['JavaScript', 'HTML/CSS', 'localStorage', 'JSON'], skills: ['CRUD', 'Export/import', 'UX utilitaire'], summary: 'Application statique de recettes avec portions dynamiques, liste de courses et sauvegarde JSON.', context: 'Projet personnel conçu pour gérer des recettes du quotidien dans une application simple, portable et sans backend obligatoire.', problem: 'Organiser des recettes et courses sans backend obligatoire.', solution: 'CRUD local, calcul des portions, export/import et synchronisation JSON possible.', deliverables: ['Catalogue de recettes', 'Calcul des portions', 'Liste de courses', 'Export/import JSON'], decisions: ['Garder une application statique pour faciliter l’hébergement', 'Utiliser le stockage local et un format JSON lisible', 'Prioriser les actions utiles en cuisine plutôt qu’une interface complexe'], learned: 'Conception d’un outil utilitaire centré sur les usages réels : données locales, édition rapide et portabilité.', impact: 'Projet utile, concret et orienté usage quotidien.', highlights: ['CRUD', 'Portions dynamiques', 'Liste de courses', 'JSON'], metrics: ['localStorage', 'Application statique'], links: { repo: 'https://github.com/steve57000/recettes', demo: 'https://steve57000.github.io/recettes/' }
   },
 
   {
-    id: 'locatech', title: 'Locatech', shortTitle: 'Location matériel', category: 'fullstack', featured: false,
-    status: 'Projet MNS / application métier', period: 'Formation MNS', role: 'Développeur fullstack', image: imageFallback, imageAlt: 'Visuel temporaire pour le projet Locatech', accent: '#3b6f8f',
+    id: 'locatech', title: 'Locatech', shortTitle: 'Location matériel', category: 'fullstack', featured: true,
+    status: 'Projet MNS / application métier', period: 'Formation MNS', role: 'Développeur fullstack', image: placeholderImage, imageAlt: 'Architecture métier Locatech générée en CSS', visual: { kind: 'api', eyebrow: 'Java / Angular', title: 'Location matériel orchestrée', metrics: ['Spring Boot', 'Angular 19', 'MySQL + MongoDB'] }, accent: '#3b6f8f',
     stack: ['Java', 'Spring Boot', 'Angular', 'TypeScript', 'SCSS', 'HTML', 'MySQL', 'MongoDB', 'Docker Compose'],
     skills: ['Architecture front/back', 'API REST', 'Données relationnelles', 'Données NoSQL', 'Conteneurisation'],
     summary: 'Application métier fullstack de location de matériel, structurée avec un frontend Angular, un backend Java Spring Boot et une orchestration Docker Compose.',
@@ -205,7 +213,7 @@ export const projects: Project[] = [
   },
   {
     id: 'bdshop', title: 'BDSHOP', shortTitle: 'Boutique', category: 'fullstack', featured: false,
-    status: 'Projet applicatif', period: 'Formation / pratique', role: 'Développeur fullstack', image: imageFallback, imageAlt: 'Visuel temporaire pour BDSHOP', accent: '#8f5a3b',
+    status: 'Projet applicatif', period: 'Formation / pratique', role: 'Développeur fullstack', image: placeholderImage, imageAlt: 'Mockup catalogue BDSHOP généré en CSS', visual: { kind: 'app', eyebrow: 'Catalogue', title: 'Boutique et parcours achat', metrics: ['Produits', 'Navigation', 'Dépôt GitHub'] }, accent: '#8f5a3b',
     stack: ['Application web'], skills: ['Catalogue', 'Architecture applicative', 'Git'],
     summary: 'Application de boutique en ligne centrée sur un catalogue produits et un parcours d’achat démonstratif.',
     problem: 'Organiser une expérience e-commerce lisible autour de produits consultables et d’une logique boutique.',
@@ -218,7 +226,7 @@ export const projects: Project[] = [
   },
   {
     id: 'compressor-img', title: 'compressorImg', shortTitle: 'Compression images', category: 'tools', featured: false,
-    status: 'Outil personnel', period: 'Projet public', role: 'Développeur front / outil', image: imageFallback, imageAlt: 'Visuel temporaire pour compressorImg', accent: '#6d6a9f',
+    status: 'Outil personnel', period: 'Projet public', role: 'Développeur front / outil', image: placeholderImage, imageAlt: 'Interface outil compressorImg générée en CSS', visual: { kind: 'tool', eyebrow: 'Web tool', title: 'Compression avant intégration', metrics: ['Optimisation', 'Navigateur', 'Workflow asset'] }, accent: '#6d6a9f',
     stack: ['Interface web'], skills: ['Optimisation', 'UX utilitaire', 'Front-end'],
     summary: 'Utilitaire front-end de compression d’images pour préparer des assets plus légers avant intégration web.',
     problem: 'Réduire le poids des images sans alourdir le workflow avec un outil serveur ou une chaîne complexe.',
@@ -231,7 +239,7 @@ export const projects: Project[] = [
   },
   { id: 'bt-carrelage', title: 'BT Carrelage', shortTitle: 'Site entreprise', category: 'fullstack', featured: false, status: 'Projet web', period: 'Projet existant', role: 'Développeur fullstack', image: btImage, imageAlt: 'Capture du site BT Carrelage', accent: '#6f5848', stack: ['React', 'Next.js', 'MongoDB'], skills: ['Cahier des charges', 'Guide technique', 'Site fullstack'], summary: 'Site pour une entreprise de carrelage, rénovation et aménagement intérieur.', problem: 'Présenter clairement une offre artisanale et ses services.', solution: 'Site web structuré autour des prestations, du savoir-faire et de la prise de contact.', impact: 'Expérience de conception et réalisation pour un contexte professionnel concret.', highlights: ['Cahier des charges', 'Guide technique', 'Responsive'], metrics: ['Site fullstack'], links: {} },
   { id: 'groupomania', title: 'Groupomania', shortTitle: 'Réseau social interne', category: 'fullstack', featured: false, status: 'Projet OpenClassrooms', period: 'Formation web', role: 'Développeur fullstack', image: groupomaniaImage, imageAlt: 'Capture du réseau social interne Groupomania', accent: '#c84b45', stack: ['Vue', 'Node.js', 'Express', 'MySQL', 'Sass'], skills: ['Auth', 'CRUD', 'Modération'], summary: "Réseau social d'entreprise avec posts, commentaires, likes, profil et modération admin.", problem: 'Créer un espace interne d’échange sécurisé.', solution: 'Frontend Vue, API Express, base MySQL et rôles de modération.', impact: 'Projet fondateur sur le fullstack JavaScript.', highlights: ['Authentification', 'Posts', 'Commentaires', 'Likes', 'Admin'], metrics: ['API REST', 'MySQL'], links: { repo: 'https://github.com/steve57000/Groupomania' } },
-  { id: 'sportsee', title: 'SportSee', shortTitle: 'Dashboard sportif', category: 'frontend', featured: false, status: 'Projet OpenClassrooms', period: 'Formation web', role: 'Développeur front', image: imageFallback, imageAlt: 'Visuel temporaire pour le dashboard SportSee', accent: '#d35445', stack: ['React', 'D3', 'Axios'], skills: ['Dataviz', 'Composants', 'API'], summary: 'Dashboard sportif avec graphiques et indicateurs utilisateur.', problem: 'Rendre des données sportives lisibles sous forme de tableaux de bord.', solution: 'Composants React, intégration API et visualisations D3.', impact: 'Bon pont entre front-end et data visualisation.', highlights: ['Graphiques', 'KPI utilisateur', 'API'], metrics: ['React', 'D3'], links: { repo: 'https://github.com/steve57000/SportSee' } },
+  { id: 'sportsee', title: 'SportSee', shortTitle: 'Dashboard sportif', category: 'frontend', featured: false, status: 'Projet OpenClassrooms', period: 'Formation web', role: 'Développeur front', image: placeholderImage, imageAlt: 'Dashboard sportif SportSee généré en CSS', visual: { kind: 'dashboard', eyebrow: 'Dataviz', title: 'KPI activité et graphiques', metrics: ['React', 'D3', 'API'] }, accent: '#d35445', stack: ['React', 'D3', 'Axios'], skills: ['Dataviz', 'Composants', 'API'], summary: 'Dashboard sportif avec graphiques et indicateurs utilisateur.', problem: 'Rendre des données sportives lisibles sous forme de tableaux de bord.', solution: 'Composants React, intégration API et visualisations D3.', impact: 'Bon pont entre front-end et data visualisation.', highlights: ['Graphiques', 'KPI utilisateur', 'API'], metrics: ['React', 'D3'], links: { repo: 'https://github.com/steve57000/SportSee' } },
   { id: 'kasa', title: 'Kasa', shortTitle: 'Location immobilière', category: 'frontend', featured: false, status: 'Projet OpenClassrooms', period: 'Formation web', role: 'Développeur React', image: kasaImage, imageAlt: 'Capture de l’application de location Kasa', accent: '#ff6f61', stack: ['React', 'React Router', 'Composants'], skills: ['Routing', 'Composants', 'Responsive'], summary: 'Application de location avec pages logement, galeries, accordéons et routing.', problem: 'Construire une SPA structurée à partir de données logements.', solution: 'React Router, composants réutilisables et interface responsive.', impact: 'Renforce les bases React et architecture de composants.', highlights: ['Routing', 'Galleries', 'Accordions'], metrics: ['SPA React'], links: { repo: 'https://github.com/steve57000/kasa', demo: 'https://steve57000.github.io/kasa/' } },
   { id: 'fisheye', title: 'FishEye', shortTitle: 'Accessibilité', category: 'frontend', featured: false, status: 'Projet OpenClassrooms', period: 'Formation web', role: 'Développeur front', image: fishEyeImage, imageAlt: 'Capture de la plateforme de photographes FishEye', accent: '#8f5e2d', stack: ['JavaScript vanilla', 'HTML/CSS', 'Accessibilité'], skills: ['A11y', 'Lightbox', 'Clavier', 'Patterns'], summary: 'Plateforme de photographes avec navigation clavier, lightbox et patterns factory/adapter.', problem: 'Créer une interface riche sans framework en respectant l’accessibilité.', solution: 'JavaScript modulaire, gestion clavier, lightbox et composants accessibles.', impact: 'Projet important pour la rigueur front-end et l’accessibilité.', highlights: ['Navigation clavier', 'Lightbox', 'Factory pattern', 'Adapter pattern'], metrics: ['Vanilla JS', 'A11y'], links: { repo: 'https://github.com/steve57000/front-end-FishEye', demo: 'https://steve57000.github.io/front-end-FishEye/' } },
   { id: 'kanap', title: 'Kanap', shortTitle: 'E-commerce', category: 'archives', featured: false, status: 'Archive / progression', period: 'Formation web', role: 'Développeur front', image: kanapImage, imageAlt: 'Capture du parcours e-commerce Kanap', accent: '#3d6f87', stack: ['JavaScript', 'API', 'localStorage'], skills: ['Panier', 'DOM', 'API'], summary: 'Parcours e-commerce avec panier, fiche produit et confirmation de commande.', problem: 'Connecter une interface statique à une API et gérer un panier.', solution: 'Appels API, stockage local et manipulation DOM.', impact: 'Étape clé dans la progression JavaScript.', highlights: ['Panier', 'Fiche produit', 'Confirmation'], metrics: ['JavaScript'], links: {} },

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,6 +10,18 @@ import { profile, projectCategories, capabilities, skills, journey, projects, fe
 import '../styles/global.css';
 import { withBase } from '../utils/paths';
 const archives = projects.filter((p) => p.category === 'archives');
+const proofStats = [
+  { value: 'Applications métier', label: 'Java / Angular, workflows et API' },
+  { value: 'SQL / Data', label: 'Modélisation, contrôle qualité, BI' },
+  { value: 'Sites publiés', label: 'Démos GitHub Pages visibles' },
+  { value: 'Projets documentés', label: 'Contexte, livrables, décisions' }
+];
+const projectGroups = [
+  { title: 'Projets clés', text: 'Les réalisations les plus alignées avec le positionnement fullstack Java/Angular + data.', items: projects.filter((p) => p.featured) },
+  { title: 'Projets actuels et data', text: 'Applications métier, bases SQL, analyses et projets en cours non sélectionnés en case study.', items: projects.filter((p) => !p.featured && ['fullstack', 'data-bi', 'frontend'].includes(p.category)) },
+  { title: 'Outils personnels publiés', text: 'Utilitaires concrets avec démo quand une version publique fiable existe.', items: projects.filter((p) => !p.featured && p.category === 'tools') },
+  { title: 'Archives OpenClassrooms', text: 'Progression web conservée en second niveau : intégration, front-end, backend, tests et conception.', items: archives }
+];
 ---
 <!doctype html>
 <html lang="fr">
@@ -56,6 +68,10 @@ const archives = projects.filter((p) => p.category === 'archives');
         </aside>
       </section>
 
+      <section class="proof-strip" aria-label="Preuves rapides" data-reveal>
+        {proofStats.map((stat) => <article><strong>{stat.value}</strong><span>{stat.label}</span></article>)}
+      </section>
+
       <section id="case-studies" class="section" data-reveal>
         <SectionHeader eyebrow="Case studies" title="5 projets qui résument le positionnement" text="Des applications métier et des projets data détaillés par contexte, problème, livrables et impact." />
         <div class="featured-grid">{featuredProjects.map((project, index) => <ProjectCard project={project} index={index} />)}</div>
@@ -64,7 +80,17 @@ const archives = projects.filter((p) => p.category === 'archives');
       <section id="projets" class="section" data-reveal>
         <SectionHeader eyebrow="Portfolio" title="Projets, outils et archives" text="Les archives OpenClassrooms restent visibles, mais les projets actuels et data sont prioritaires." />
         <div class="filters" aria-label="Filtrer les projets">{projectCategories.map((cat) => <button type="button" data-filter={cat.id} class={cat.id === 'all' ? 'is-active' : ''} aria-pressed={cat.id === 'all' ? 'true' : 'false'}><Icon name={cat.icon} />{cat.label}</button>)}</div>
-        <div class="project-grid" data-project-grid>{projects.map((project, index) => <ProjectCard project={project} index={index} />)}</div>
+        <div class="project-catalog" data-project-grid>
+          {projectGroups.map((group) => group.items.length > 0 && (
+            <section class="project-group" data-project-group>
+              <div class="project-group__head">
+                <h3>{group.title}</h3>
+                <p>{group.text}</p>
+              </div>
+              <div class="project-grid">{group.items.map((project, index) => <ProjectCard project={project} index={index} />)}</div>
+            </section>
+          ))}
+        </div>
         <p class="project-empty" data-project-empty aria-live="polite" hidden>Aucun projet dans ce filtre pour le moment.</p>
         <p class="archive-note">Archives OpenClassrooms visibles : {archives.length} projets secondaires documentant la progression web.</p>
       </section>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -375,3 +375,75 @@ button, a { outline-offset: 4px; }
 .detail-grid h4, .project-detail__learned h4, .project-detail__stack h4, .project-proof h5 { --icon-badge-size: 2rem; --icon-in-badge-size: 1rem; --icon-gap: 0.55rem; }
 .site-footer address .icon-link { text-decoration: none; color: var(--muted); font-weight: 800; }
 .site-footer address a.icon-link:hover { color: var(--ink); }
+
+/* proof strip */
+.proof-strip {
+  display: grid;
+  width: var(--wrap);
+  max-width: calc(100% - clamp(2rem, 8vw, 8rem));
+  margin: clamp(-2rem, -2vw, -1rem) auto clamp(3rem, 6vw, 5rem);
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.85rem;
+}
+.proof-strip article {
+  border: 1px solid color-mix(in srgb, var(--line), #fff 30%);
+  border-radius: 1.1rem;
+  background: linear-gradient(135deg, rgba(255,253,247,0.86), rgba(255,248,234,0.66));
+  box-shadow: var(--shadow-soft);
+  padding: clamp(1rem, 2vw, 1.25rem);
+}
+.proof-strip strong { display: block; color: var(--ink); font-size: 1rem; letter-spacing: -0.02em; }
+.proof-strip span { display: block; margin-top: 0.25rem; color: var(--muted); font-size: 0.88rem; line-height: 1.45; }
+
+/* generated project visuals */
+.project-visual {
+  position: relative;
+  min-height: 100%;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--accent), #fff 62%);
+  border-radius: inherit;
+  background:
+    radial-gradient(circle at 16% 12%, rgba(255,255,255,0.7), transparent 24%),
+    linear-gradient(135deg, color-mix(in srgb, var(--accent), #101615 20%), #151d1b 68%);
+  color: #fffdf7;
+  isolation: isolate;
+}
+.project-visual::before,
+.project-visual::after { content: ""; position: absolute; border-radius: 999px; z-index: -1; }
+.project-visual::before { width: 11rem; height: 11rem; right: -3rem; top: -4rem; background: color-mix(in srgb, var(--accent), transparent 35%); filter: blur(10px); }
+.project-visual::after { width: 15rem; height: 15rem; left: -5rem; bottom: -7rem; border: 1px solid rgba(255,255,255,0.2); background: rgba(255,255,255,0.06); }
+.project-visual__chrome { display: flex; gap: 0.38rem; padding: 0.85rem 0.95rem 0; }
+.project-visual__chrome span { width: 0.5rem; height: 0.5rem; border-radius: 50%; background: rgba(255,255,255,0.56); }
+.project-visual__content { display: grid; gap: 0.7rem; padding: 0.9rem clamp(1rem, 2vw, 1.35rem) 1.2rem; }
+.project-visual p { margin: 0; color: color-mix(in srgb, var(--accent), #fff 62%); font-size: 0.72rem; font-weight: 900; letter-spacing: 0.14em; text-transform: uppercase; }
+.project-visual strong { max-width: 18rem; font-size: clamp(1.05rem, 2vw, 1.42rem); line-height: 1.08; letter-spacing: -0.04em; }
+.project-visual ul { display: flex; flex-wrap: wrap; gap: 0.45rem; padding: 0; margin: 0; list-style: none; }
+.project-visual li { border: 1px solid rgba(255,255,255,0.18); border-radius: 999px; background: rgba(255,255,255,0.1); padding: 0.28rem 0.55rem; font-size: 0.68rem; font-weight: 850; }
+.visual-panels { display: grid; grid-template-columns: 1.15fr 0.85fr; gap: 0.5rem; }
+.visual-panels span { min-height: 1.65rem; border: 1px solid rgba(255,255,255,0.14); border-radius: 0.65rem; background: linear-gradient(135deg, rgba(255,255,255,0.2), rgba(255,255,255,0.06)); box-shadow: inset 0 1px 0 rgba(255,255,255,0.18); }
+.visual-panels span:first-child { grid-row: span 2; min-height: 3.8rem; }
+.visual-sql { display: grid; gap: 0.28rem; border: 1px solid rgba(255,255,255,0.14); border-radius: 0.75rem; background: rgba(0,0,0,0.22); padding: 0.7rem; font-size: 0.74rem; }
+.visual-sql code { color: #dff6ee; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+.visual-api { display: grid; grid-template-columns: 1fr auto 1fr auto 1fr; align-items: center; gap: 0.45rem; }
+.visual-api span { border: 1px solid rgba(255,255,255,0.16); border-radius: 0.75rem; background: rgba(255,255,255,0.1); padding: 0.7rem 0.5rem; text-align: center; font-size: 0.72rem; font-weight: 900; }
+.visual-api i { height: 2px; min-width: 0.8rem; background: color-mix(in srgb, var(--accent), #fff 50%); }
+.project-card:hover .project-visual { transform: scale(1.01); }
+
+/* portfolio hierarchy */
+.project-catalog { display: grid; gap: clamp(2rem, 4vw, 3rem); width: var(--wrap); max-width: 100%; margin-inline: auto; }
+.project-group[hidden] { display: none; }
+.project-group__head { max-width: 52rem; margin-bottom: 1rem; }
+.project-group__head h3 { margin: 0; font-size: clamp(1.45rem, 3vw, 2.2rem); line-height: 1; letter-spacing: -0.045em; }
+.project-group__head p { margin: 0.45rem 0 0; color: var(--muted); }
+.project-group:last-child .project-card { opacity: 0.9; }
+.project-group:last-child .project-card:not(:hover) { box-shadow: 0 12px 30px rgba(38, 31, 21, 0.08); }
+
+@media (max-width: 900px) {
+  .proof-strip { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+@media (max-width: 560px) {
+  .proof-strip { grid-template-columns: 1fr; }
+  .visual-api { grid-template-columns: 1fr; }
+  .visual-api i { width: 2px; height: 0.75rem; justify-self: center; }
+}


### PR DESCRIPTION
### Motivation
- Réduire l’effet de « placeholder générique » et proposer des visuels premium générés en HTML/CSS quand il n’existe pas de vraie capture. 
- Mieux vendre les projets clés en rééquilibrant les case studies vers le positionnement Fullstack Java/Angular + Data. 
- Améliorer la hiérarchie des projets et l’expérience (preuve rapide, groupes, démos clairement indiquées) sans ajouter de fichiers binaires ni nouveaux packages.

### Description
- Ajout d’un type optionnel `ProjectVisual` et extension du modèle `Project` pour décrire un visuel généré (`src/data/portfolioData.ts`) et attribution de visuels aux projets sans capture, avec quelques ajustements des flags `featured` (ex. JLH AutoPam, BottleNeck, Assurance habitation, Guide Investissement, Locatech). 
- Nouveau composant `src/components/ProjectVisual.astro` qui produit des mini-interfaces (dashboard / data panels / SQL snippet / API flow / mockups) en HTML/CSS pur; `src/components/ProjectCard.astro` a été modifié pour rendre ce visuel quand `project.visual` existe et sinon conserver l’image importée existante. 
- Réorganisation de la page d’accueil `src/pages/index.astro` : ajout d’une bande de preuves après le hero, et réorganisation de la section projets en groupes hiérarchisés (`Projets clés`, `Projets actuels et data`, `Outils personnels publiés`, `Archives OpenClassrooms`). 
- Styles et comportement : ajout des styles CSS pour les visuels et la hiérarchie dans `src/styles/global.css` et adaptation du script client `public/scripts/main.js` pour masquer proprement les groupes vides lors du filtrage; la variable de repli d’image a été renommée internement pour clarté (`placeholderImage`) sans toucher aux imports binaires d’images.

### Testing
- `npm ci` exécuté localement et terminé sans erreur. 
- `ASTRO_TELEMETRY_DISABLED=1 npm run build` exécuté et la compilation statique a réussi (build complet des pages). 
- Recherches automatisées (`rg -n 'href="/|src="/' src` et `rg -n "Visuel temporaire|imageFallback" src/data/portfolioData.ts`) effectuées pour vérifier les chemins GitHub Pages et la suppression des placeholders, avec résultats conformes aux attentes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4935977b5c832cafb343dbbe76fc1f)