### PR TITLE
Improve project grid and CSS visuals

### DIFF
--- a/src/components/ProjectVisual.astro
+++ b/src/components/ProjectVisual.astro
@@ -3,6 +3,7 @@ import type { ProjectVisual as ProjectVisualType } from '../data/portfolioData';
 
 const { visual, title } = Astro.props as { visual: ProjectVisualType; title: string };
 const metrics = visual.metrics?.slice(0, 3) ?? [];
+const panelKinds = ['dashboard', 'data', 'app', 'tool', 'document'];
 ---
 <div class:list={["project-visual", `project-visual--${visual.kind}`]} role="img" aria-label={`Visuel CSS du projet ${title}`}>
   <div class="project-visual__chrome"><span></span><span></span><span></span></div>
@@ -24,8 +25,8 @@ const metrics = visual.metrics?.slice(0, 3) ?? [];
       </div>
     )}
 
-    {['dashboard', 'data', 'app', 'tool', 'document'].includes(visual.kind) && (
-      <div class="visual-panels" aria-hidden="true">
+    {panelKinds.includes(visual.kind) && (
+      <div class:list={["visual-panels", `visual-panels--${visual.kind}`]} aria-hidden="true">
         <span></span><span></span><span></span><span></span>
       </div>
     )}

--- a/src/data/portfolioData.ts
+++ b/src/data/portfolioData.ts
@@ -257,4 +257,8 @@ export const projects: Project[] = [
 
 ];
 
-export const featuredProjects: Project[] = projects.filter((project) => project.featured);
+export const featuredProjectIds = ['jlh-autopam', 'locatech', 'bottleneck', 'assurance-data', 'guide-investissement'] as const;
+
+export const featuredProjects: Project[] = featuredProjectIds
+  .map((id) => projects.find((project) => project.id === id))
+  .filter((project): project is Project => Boolean(project));

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -17,7 +17,7 @@ const proofStats = [
   { value: 'Projets documentés', label: 'Contexte, livrables, décisions' }
 ];
 const projectGroups = [
-  { title: 'Projets clés', text: 'Les réalisations les plus alignées avec le positionnement fullstack Java/Angular + data.', items: projects.filter((p) => p.featured) },
+  { title: 'Projets clés', text: 'Les réalisations les plus alignées avec le positionnement fullstack Java/Angular, applications métier, SQL/data et projets publiés.', items: featuredProjects },
   { title: 'Projets actuels et data', text: 'Applications métier, bases SQL, analyses et projets en cours non sélectionnés en case study.', items: projects.filter((p) => !p.featured && ['fullstack', 'data-bi', 'frontend'].includes(p.category)) },
   { title: 'Outils personnels publiés', text: 'Utilitaires concrets avec démo quand une version publique fiable existe.', items: projects.filter((p) => !p.featured && p.category === 'tools') },
   { title: 'Archives OpenClassrooms', text: 'Progression web conservée en second niveau : intégration, front-end, backend, tests et conception.', items: archives }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -167,7 +167,7 @@ button, a { outline-offset: 4px; }
   width: var(--wrap);
   max-width: 100%;
   margin-inline: auto;
-  gap: clamp(1.35rem, 2.4vw, 2.15rem);
+  gap: clamp(1.45rem, 2.2vw, 2.35rem);
   grid-template-columns: 1fr;
 }
 .project-card {
@@ -181,19 +181,19 @@ button, a { outline-offset: 4px; }
 }
 .project-card::before { content: ""; height: 5px; background: linear-gradient(90deg, var(--accent), color-mix(in srgb, var(--accent), #fff 52%)); }
 .project-card__media { overflow: hidden; background: #ddd6ca; }
-.project-card img { width: 100%; aspect-ratio: 16 / 9; object-fit: cover; transition: transform 450ms ease, filter 220ms ease; }
-.project-card__body { display: flex; flex: 1; flex-direction: column; gap: 1rem; padding: clamp(1.35rem, 2vw, 1.75rem); }
+.project-card img { width: 100%; aspect-ratio: 16 / 10; object-fit: cover; transition: transform 450ms ease, filter 220ms ease; }
+.project-card__body { display: flex; flex: 1; flex-direction: column; gap: 1.05rem; padding: clamp(1.35rem, 2vw, 1.8rem); }
 .project-card__meta { display: flex; justify-content: space-between; gap: 0.5rem; color: var(--muted); font-size: 0.74rem; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; }
 .project-card h3 { margin: 0; font-size: clamp(1.35rem, 2vw, 1.55rem); line-height: 1.08; letter-spacing: -0.035em; }
 .project-card p { margin: 0; color: #43504a; line-height: 1.65; }
-.project-card .tags { margin-top: auto; padding-top: 0.3rem; }
+.project-card .tags { margin-top: auto; margin-bottom: 0; padding-top: 0.45rem; padding-bottom: 0.15rem; }
 .project-card:hover { transform: translateY(-4px); border-color: color-mix(in srgb, var(--accent), var(--line) 45%); box-shadow: var(--shadow-hover); }
 .project-card:hover img { transform: scale(1.045); filter: saturate(1.05) contrast(1.03); }
 .project-grid .project-card[hidden], .project-grid .project-card.is-filtered-out { display: none; }
 .tags { display: flex; flex-wrap: wrap; gap: 0.55rem; padding: 0; margin: 1rem 0; list-style: none; }
 .tags li { border: 1px solid color-mix(in srgb, var(--accent), #fff 55%); background: color-mix(in srgb, var(--accent), #fff 90%); border-radius: 999px; padding: 0.36rem 0.72rem; font-size: 0.78rem; font-weight: 750; line-height: 1.1; }
 .text-link { color: var(--accent); font-weight: 900; text-decoration-thickness: 0.12em; text-underline-offset: 0.2em; }
-.project-card__actions { margin-top: 0.55rem; padding-top: 0.2rem; gap: 0.65rem; }
+.project-card__actions { display: flex; flex-wrap: wrap; align-items: center; margin-top: 0.6rem; padding-top: 0.35rem; gap: 0.65rem; }
 .project-card__actions .button { min-height: 3rem; padding-inline: 1.05rem; }
 .project-card__actions .text-link {
   border: 1px solid color-mix(in srgb, var(--accent), var(--line) 58%);
@@ -294,7 +294,7 @@ button, a { outline-offset: 4px; }
   .project-proof__grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
   .project-proof__grid article:first-child { grid-column: auto; }
 }
-@media (min-width: 1680px) {
+@media (min-width: 1800px) {
   .featured-grid, .project-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); }
   .skill-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); }
 }
@@ -399,7 +399,7 @@ button, a { outline-offset: 4px; }
 .project-visual {
   position: relative;
   min-height: 100%;
-  aspect-ratio: 16 / 9;
+  aspect-ratio: 16 / 10;
   overflow: hidden;
   border: 1px solid color-mix(in srgb, var(--accent), #fff 62%);
   border-radius: inherit;
@@ -421,8 +421,17 @@ button, a { outline-offset: 4px; }
 .project-visual ul { display: flex; flex-wrap: wrap; gap: 0.45rem; padding: 0; margin: 0; list-style: none; }
 .project-visual li { border: 1px solid rgba(255,255,255,0.18); border-radius: 999px; background: rgba(255,255,255,0.1); padding: 0.28rem 0.55rem; font-size: 0.68rem; font-weight: 850; }
 .visual-panels { display: grid; grid-template-columns: 1.15fr 0.85fr; gap: 0.5rem; }
-.visual-panels span { min-height: 1.65rem; border: 1px solid rgba(255,255,255,0.14); border-radius: 0.65rem; background: linear-gradient(135deg, rgba(255,255,255,0.2), rgba(255,255,255,0.06)); box-shadow: inset 0 1px 0 rgba(255,255,255,0.18); }
+.visual-panels span { position: relative; min-height: 1.65rem; overflow: hidden; border: 1px solid rgba(255,255,255,0.14); border-radius: 0.65rem; background: linear-gradient(135deg, rgba(255,255,255,0.2), rgba(255,255,255,0.06)); box-shadow: inset 0 1px 0 rgba(255,255,255,0.18); }
 .visual-panels span:first-child { grid-row: span 2; min-height: 3.8rem; }
+.visual-panels--dashboard span:first-child::before,
+.visual-panels--data span:first-child::before { content: ""; position: absolute; inset: 18% 12% 16%; background: linear-gradient(90deg, transparent 0 8%, rgba(255,255,255,0.72) 8% 12%, transparent 12% 28%, rgba(255,255,255,0.5) 28% 34%, transparent 34% 54%, rgba(255,255,255,0.82) 54% 60%, transparent 60%); }
+.visual-panels--app span:first-child { background: linear-gradient(180deg, rgba(255,255,255,0.24) 0 24%, rgba(255,255,255,0.08) 24%), linear-gradient(135deg, rgba(255,255,255,0.18), rgba(255,255,255,0.05)); }
+.visual-panels--app span:nth-child(2)::before,
+.visual-panels--tool span:nth-child(2)::before { content: ""; position: absolute; inset: 35% 18%; border-radius: 999px; background: rgba(255,255,255,0.62); }
+.visual-panels--document { grid-template-columns: 0.85fr 1.15fr; }
+.visual-panels--document span:first-child { background: linear-gradient(180deg, rgba(255,255,255,0.26), rgba(255,255,255,0.08)); }
+.visual-panels--document span:first-child::before { content: ""; position: absolute; inset: 20% 18%; background: repeating-linear-gradient(180deg, rgba(255,255,255,0.7) 0 2px, transparent 2px 9px); }
+.visual-panels--tool span:first-child::before { content: "⚙"; position: absolute; inset: 0; display: grid; place-items: center; color: rgba(255,255,255,0.72); font-size: 1.65rem; }
 .visual-sql { display: grid; gap: 0.28rem; border: 1px solid rgba(255,255,255,0.14); border-radius: 0.75rem; background: rgba(0,0,0,0.22); padding: 0.7rem; font-size: 0.74rem; }
 .visual-sql code { color: #dff6ee; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
 .visual-api { display: grid; grid-template-columns: 1fr auto 1fr auto 1fr; align-items: center; gap: 0.45rem; }


### PR DESCRIPTION
### Motivation
- Rendre la grille de cartes projets plus lisible et respirante en évitant 4 cartes serrées sur un desktop classique et en garantissant des cartes de taille cohérente quand le filtre réduit les résultats.
- Remplacer les visuels fallback uniformes par des rendus CSS/HTML premium pour les projets sans vraie capture afin d’avoir des visuels plus lisibles sans ajouter d’assets binaires.
- Mettre en avant une sélection maximale de 5 case studies mieux alignés avec le positionnement fullstack Java/Angular + data.

### Description
- Ajuste le responsive des grilles `.featured-grid` et `.project-grid` pour respecter 1 colonne mobile, 2 colonnes tablette (`min-width: 680px`), 3 colonnes desktop (`min-width: 1024px`) et basculer à 4 colonnes uniquement sur très grands écrans (`min-width: 1800px`). (modifié : `src/styles/global.css`).
- Agrandit et aère les médias de cartes en changeant le ratio d’image à `16/10`, augmente les gaps, ajuste paddings/gaps/tags et rend les actions plus stables pour éviter des cartes surdimensionnées. (modifié : `src/styles/global.css`).
- Enrichit `ProjectVisual.astro` et le CSS associé pour proposer plusieurs variantes de visuels CSS premium (`dashboard`, `data`, `sql`, `app`, `api`, `document`, `tool`) et ajoute des classes variantes (`visual-panels--*`) pour des rendus plus premium sans fichier binaire. (modifié : `src/components/ProjectVisual.astro`, `src/styles/global.css`).
- Fige la sélection des case studies à une liste explicite de 5 IDs (`jlh-autopam`, `locatech`, `bottleneck`, `assurance-data`, `guide-investissement`) et aligne la section « Projets clés » sur cette sélection. (modifié : `src/data/portfolioData.ts`, `src/pages/index.astro`).
- Changements non invasifs : les vraies captures d’écran existantes sont conservées, aucun asset PNG/JPG/ICO/WEBP ajouté ou modifié et aucun package externe ajouté.

### Testing
- `npm ci` — OK (install completed).
- `ASTRO_TELEMETRY_DISABLED=1 npm run build` — OK (site statique généré, 3 pages built).
- Recherches/contrôles automatisés `rg -n 'href="/|src="/' src` et `rg -n "Visuel temporaire|imageFallback" src/data/portfolioData.ts` — OK (pas de lien absolu problématique ni d’ancien fallback nommé restant).
- Contrôles git `git diff --numstat` et `git diff --check` — OK (diffs propres), commit réalisé.
- Capture automatisée via Playwright non exécutée car `playwright` n’est pas installé dans l’environnement; aucune dépendance supplémentaire n’a été ajoutée conformément aux contraintes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a493787bccc832cb2bdffcb3c19d6b8)