### PR TITLE
Improve project section reveal timing so header and filters appear earlier

### DIFF
--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -49,16 +49,25 @@ filterButtons.forEach((button) => {
 });
 
 const revealElements = document.querySelectorAll('[data-reveal]');
+const revealElement = (entry, observer) => {
+  if (!entry.isIntersecting) return;
+  entry.target.classList.add('is-revealed');
+  observer.unobserve(entry.target);
+};
+
 if ('IntersectionObserver' in window && !window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
   const revealObserver = new IntersectionObserver((entries, observer) => {
-    entries.forEach((entry) => {
-      if (!entry.isIntersecting) return;
-      entry.target.classList.add('is-revealed');
-      observer.unobserve(entry.target);
-    });
-  }, { rootMargin: '0px 0px -8% 0px', threshold: 0.12 });
+    entries.forEach((entry) => revealElement(entry, observer));
+  }, { rootMargin: '0px 0px -2% 0px', threshold: 0.04 });
 
-  revealElements.forEach((element) => revealObserver.observe(element));
+  const earlyRevealObserver = new IntersectionObserver((entries, observer) => {
+    entries.forEach((entry) => revealElement(entry, observer));
+  }, { rootMargin: '0px 0px 8% 0px', threshold: 0.01 });
+
+  revealElements.forEach((element) => {
+    const observer = element.dataset.reveal === 'early' ? earlyRevealObserver : revealObserver;
+    observer.observe(element);
+  });
 } else {
   revealElements.forEach((element) => element.classList.add('is-revealed'));
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -78,13 +78,13 @@ const projectGroups = [
         <div class="featured-grid">{featuredProjects.map((project, index) => <ProjectCard project={project} index={index} />)}</div>
       </section>
 
-      <section id="projets" class="section" data-reveal>
+      <section id="projets" class="section">
         <SectionHeader eyebrow="Portfolio" title="Projets, outils et fondations web" text="Chaque projet présente un contexte, une stack, des décisions et les liens disponibles." />
-        <div class="filters" aria-label="Filtrer les projets">{projectCategories.map((cat) => <button type="button" data-filter={cat.id} class={cat.id === 'all' ? 'is-active' : ''} aria-pressed={cat.id === 'all' ? 'true' : 'false'}><Icon name={cat.icon} />{cat.label}</button>)}</div>
+        <div class="filters" aria-label="Filtrer les projets" data-reveal="early">{projectCategories.map((cat) => <button type="button" data-filter={cat.id} class={cat.id === 'all' ? 'is-active' : ''} aria-pressed={cat.id === 'all' ? 'true' : 'false'}><Icon name={cat.icon} />{cat.label}</button>)}</div>
         <div class="project-catalog" data-project-grid>
           {projectGroups.map((group) => group.items.length > 0 && (
             <section class="project-group" data-project-group>
-              <div class="project-group__head">
+              <div class="project-group__head" data-reveal="early">
                 <h3>{group.title}</h3>
                 <p>{group.text}</p>
               </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -317,6 +317,7 @@ button, a { outline-offset: 4px; }
 }
 
 /* animations */
+#projets { opacity: 1; transform: none; }
 [data-reveal] { opacity: 0; transform: translateY(18px); transition: opacity 520ms ease, transform 520ms ease; transition-delay: var(--reveal-delay, 0ms); }
 [data-reveal].is-revealed { opacity: 1; transform: none; }
 @keyframes dialog-in { from { opacity: 0; transform: translateY(12px) scale(0.98); } to { opacity: 1; transform: none; } }


### PR DESCRIPTION
### Motivation
- The full `#projets` section was treated as one large reveal block which delayed showing the title and filters when scrolling. 
- The goal is to make the portfolio header, filters and group headings visible earlier while keeping gentle card animations and avoiding layout shifts. 
- Keep the grid breakpoints unchanged so 3 columns are used on typical large desktops and 4 columns only at `min-width: 2400px`.

### Description
- Stop revealing the whole projects section by removing `data-reveal` from `<section id="projets">`. 
- Add early reveal markers by setting `data-reveal="early"` on the filters container and each `.project-group__head`. 
- Update `public/scripts/main.js` to add a small `revealElement` helper, relax the main observer to `{ rootMargin: '0px 0px -2% 0px', threshold: 0.04 }`, and add an `earlyRevealObserver` with `{ rootMargin: '0px 0px 8% 0px', threshold: 0.01 }` that targets elements with `data-reveal="early"`. 
- Add a safety CSS rule `#projets { opacity: 1; transform: none; }` before the `[data-reveal]` rule to avoid accidentally hiding the whole catalogue, and preserve existing per-card `data-reveal` animations in `ProjectCard`. 
- Verified that the 4-column grid remains under the media query `@media (min-width: 2400px)` and 3-column layout starts at `1024px`.

### Testing
- Installed dependencies with `npm ci --no-audit --no-fund` and it completed successfully. 
- Ran the production build with `ASTRO_TELEMETRY_DISABLED=1 npm run build` and the build succeeded. 
- Searched styles with `rg -n "min-width: 1800px|min-width: 1920px|repeat\(4" src/styles/global.css` to confirm the 4-column breakpoint remains at `2400px`. 
- Searched for reveal-related patterns with `rg -n "rootMargin|threshold|data-reveal|#projets" public/scripts/main.js src/pages/index.astro src/styles/global.css` to verify the JS and template changes. 
- Inspected `git diff --numstat` to confirm three files were modified and changes committed; all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4942704e58832c8c0e9cf09c7c5876)