### PR TITLE
Polish mobile Focus, add About section, and implement accessible light/dark theme with paint transition

### DIFF
--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -7,6 +7,84 @@ navToggle?.addEventListener('click', () => {
   nav?.classList.toggle('is-open', !expanded);
 });
 
+const themeToggle = document.querySelector('[data-theme-toggle]');
+const themeMeta = document.querySelector('meta[name="theme-color"]');
+const themeStorageKey = 'portfolio-theme';
+const reducedMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+const systemDarkQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+const getStoredTheme = () => {
+  try { return localStorage.getItem(themeStorageKey); } catch { return null; }
+};
+
+const storeTheme = (theme) => {
+  try { localStorage.setItem(themeStorageKey, theme); } catch {}
+};
+
+const getSystemTheme = () => systemDarkQuery.matches ? 'dark' : 'light';
+const getTheme = () => document.documentElement.dataset.theme === 'dark' ? 'dark' : 'light';
+
+const setThemeMeta = (theme) => {
+  themeMeta?.setAttribute('content', theme === 'dark' ? '#0b1110' : '#f5f1e8');
+};
+
+const syncThemeToggle = () => {
+  if (!themeToggle) return;
+  const dark = getTheme() === 'dark';
+  themeToggle.setAttribute('aria-pressed', String(dark));
+  themeToggle.setAttribute('aria-label', dark ? 'Activer le mode clair' : 'Activer le mode sombre');
+};
+
+const applyTheme = (theme) => {
+  document.documentElement.dataset.theme = theme;
+  setThemeMeta(theme);
+  syncThemeToggle();
+};
+
+applyTheme(getStoredTheme() === 'dark' || getStoredTheme() === 'light' ? getStoredTheme() : getTheme());
+
+systemDarkQuery.addEventListener?.('change', () => {
+  if (!getStoredTheme()) applyTheme(getSystemTheme());
+});
+
+const createPaintOverlay = (targetTheme) => {
+  const paint = document.createElement('div');
+  paint.className = 'theme-paint';
+  paint.dataset.themePaint = targetTheme;
+  paint.setAttribute('aria-hidden', 'true');
+  for (let index = 0; index < 7; index += 1) {
+    const drip = document.createElement('span');
+    drip.style.setProperty('--drip-index', String(index));
+    paint.appendChild(drip);
+  }
+  document.body.appendChild(paint);
+  return paint;
+};
+
+const animateThemeChange = (targetTheme) => {
+  if (reducedMotionQuery.matches) {
+    applyTheme(targetTheme);
+    storeTheme(targetTheme);
+    return;
+  }
+
+  const paint = createPaintOverlay(targetTheme);
+  window.setTimeout(() => {
+    applyTheme(targetTheme);
+    storeTheme(targetTheme);
+    paint.classList.add('is-finished');
+  }, 420);
+  paint.addEventListener('animationend', (event) => {
+    if (event.animationName === 'paint-exit') paint.remove();
+  });
+  window.setTimeout(() => paint.remove(), 1300);
+};
+
+themeToggle?.addEventListener('click', () => {
+  const nextTheme = getTheme() === 'dark' ? 'light' : 'dark';
+  animateThemeChange(nextTheme);
+});
+
 const projectGrid = document.querySelector('[data-project-grid]');
 const filterButtons = document.querySelectorAll('[data-filter]');
 const emptyState = document.querySelector('[data-project-empty]');

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -4,7 +4,13 @@ import { withBase } from '../utils/paths';
 ---
 <header class="site-header">
   <a class="brand" href={withBase()} aria-label="Accueil Steve Bell"><span>SB</span><strong>Steve Bell</strong></a>
-  <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-nav">Menu</button>
+  <div class="header-actions">
+    <button class="theme-toggle" type="button" aria-label="Activer le mode sombre" aria-pressed="false" data-theme-toggle>
+      <span class="theme-toggle__track" aria-hidden="true"><span class="theme-toggle__thumb"></span></span>
+      <span class="theme-toggle__text">Thème</span>
+    </button>
+    <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-nav">Menu</button>
+  </div>
   <nav id="site-nav" class="site-nav" aria-label="Navigation principale">
     <a class="nav-link" href={withBase('#projets')}><Icon name="projects" />Projets</a><a class="nav-link" href={withBase('#case-studies')}><Icon name="case-studies" />Case studies</a><a class="nav-link" href={withBase('#competences')}><Icon name="competences" />Compétences</a><a class="nav-link" href={withBase('#parcours')}><Icon name="journey" />Parcours</a><a class="nav-link" href={withBase('cv/')}><Icon name="cv" />CV</a><a class="nav-link" href={withBase('#contact')}><Icon name="contact" />Contact</a>
   </nav>

--- a/src/data/portfolioData.ts
+++ b/src/data/portfolioData.ts
@@ -73,6 +73,25 @@ export const profile = {
   }
 };
 
+
+export const about = {
+  eyebrow: 'À propos de moi',
+  title: 'Construire des outils utiles, lisibles et vérifiables',
+  intro: 'Je construis un profil volontairement hybride : applications métier Java/Angular, backends structurés, SQL et données exploitables. Basé autour de Metz / Ars-sur-Moselle, mon parcours m’a amené du développement web React à la conception Java/Angular, puis à l’analyse data/BI. Ce qui m’intéresse surtout : transformer un besoin réel en outil clair, documenté et utilisable.',
+  body: 'J’aime relier les pièces qui font tenir un projet : interface, API, base de données, contrôle qualité et documentation. L’objectif n’est pas de multiplier les effets, mais de livrer des projets consultables, maintenables et compréhensibles par une personne métier comme par un profil technique.',
+  points: [
+    'Comprendre le besoin avant l’écran.',
+    'Structurer l’application et la donnée.',
+    'Documenter les choix techniques.',
+    'Livrer des projets consultables et maintenables.'
+  ],
+  path: [
+    'OpenClassrooms : développement web / logiciel React.',
+    'Metz Numeric School : conception logiciel Java / Angular.',
+    'Formation data / BI : SQL, Python, nettoyage, modélisation, qualité de données, restitution.'
+  ]
+};
+
 export const projectCategories: { id: ProjectCategory; label: string; icon: string }[] = [
   { id: 'all', label: 'Tous', icon: 'filters' },
   { id: 'fullstack', label: 'Fullstack', icon: 'fullstack' },

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,7 +6,7 @@ import ProjectDetails from '../components/ProjectDetails.astro';
 import SectionHeader from '../components/SectionHeader.astro';
 import Icon from '../components/Icon.astro';
 import SeoHead from '../components/SeoHead.astro';
-import { profile, projectCategories, capabilities, skills, journey, projects, featuredProjects } from '../data/portfolioData';
+import { profile, about, projectCategories, capabilities, skills, journey, projects, featuredProjects } from '../data/portfolioData';
 import '../styles/global.css';
 import { withBase } from '../utils/paths';
 const archives = projects.filter((p) => p.category === 'archives');
@@ -24,10 +24,22 @@ const projectGroups = [
 ];
 ---
 <!doctype html>
-<html lang="fr">
+<html lang="fr" data-theme="light">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
+    <script is:inline>
+      (() => {
+        const storageKey = 'portfolio-theme';
+        const root = document.documentElement;
+        const getSystemTheme = () => window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        const savedTheme = (() => { try { return localStorage.getItem(storageKey); } catch { return null; } })();
+        const theme = savedTheme === 'dark' || savedTheme === 'light' ? savedTheme : getSystemTheme();
+        root.dataset.theme = theme;
+        const meta = document.querySelector('meta[name="theme-color"]');
+        meta?.setAttribute('content', theme === 'dark' ? '#0b1110' : '#f5f1e8');
+      })();
+    </script>
     <SeoHead
       title="Steve Bell — Fullstack Java Angular & Data Analyst junior"
       description="Portfolio de Steve Bell : applications métier, API sécurisées, SQL, dashboards et projets data."
@@ -71,6 +83,28 @@ const projectGroups = [
 
       <section class="proof-strip" aria-label="Preuves rapides" data-reveal>
         {proofStats.map((stat) => <article><strong>{stat.value}</strong><span>{stat.label}</span></article>)}
+      </section>
+
+
+      <section class="about section" aria-labelledby="about-title" data-reveal>
+        <div class="about__card">
+          <div class="about__content">
+            <p class="eyebrow">{about.eyebrow}</p>
+            <h2 id="about-title">{about.title}</h2>
+            <p class="about__lead">{about.intro}</p>
+            <p>{about.body}</p>
+            <ul class="about__points">
+              {about.points.map((point) => <li><span class="icon-badge icon-badge--sm"><Icon name="quality" /></span>{point}</li>)}
+            </ul>
+          </div>
+          <aside class="about__path" aria-label="Parcours résumé">
+            <strong>{profile.name}</strong>
+            <span>{profile.location}</span>
+            <ol>
+              {about.path.map((item) => <li>{item}</li>)}
+            </ol>
+          </aside>
+        </div>
       </section>
 
       <section id="case-studies" class="section" data-reveal>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -459,3 +459,170 @@ button, a { outline-offset: 4px; }
   .visual-api { grid-template-columns: 1fr; }
   .visual-api i { width: 2px; height: 0.75rem; justify-self: center; }
 }
+
+/* theme system and premium pass */
+:root {
+  color-scheme: light;
+  --bg-rgb: 245 241 232;
+  --ink-rgb: 23 32 29;
+  --surface-glass: rgba(245, 241, 232, 0.92);
+  --copy: #39443f;
+  --copy-soft: #43504a;
+  --chip-bg: #fff8ea;
+  --paint-color: #f5f1e8;
+  --shadow-soft: 0 20px 60px rgba(38, 31, 21, 0.08);
+  --shadow-card: 0 18px 45px rgba(38, 31, 21, 0.12);
+  --shadow-hover: 0 28px 76px rgba(38, 31, 21, 0.18);
+}
+
+html[data-theme="dark"] {
+  color-scheme: dark;
+  --bg: #0b1110;
+  --bg-rgb: 11 17 16;
+  --ink: #f4efe4;
+  --ink-rgb: 244 239 228;
+  --muted: #aeb9b1;
+  --panel: #121b19;
+  --panel-strong: #18231f;
+  --line: #2a3934;
+  --accent: #65c7ad;
+  --dark: #f4efe4;
+  --surface-glass: rgba(11, 17, 16, 0.88);
+  --copy: #d7ded8;
+  --copy-soft: #c4cec7;
+  --chip-bg: #16211e;
+  --paint-color: #0b1110;
+  --shadow-soft: 0 20px 70px rgba(0, 0, 0, 0.34);
+  --shadow-card: 0 22px 58px rgba(0, 0, 0, 0.42);
+  --shadow-hover: 0 30px 84px rgba(0, 0, 0, 0.5);
+}
+
+html, body, .site-header, .hero__focus, .project-card, .skill-grid article, .timeline li, .site-footer, .project-dialog__panel, .proof-strip article, .filters button, .tags li, .button, .project-detail__summary, .project-detail__learned, .project-proof, .project-detail__stack, .detail-grid section, .about__card, .about__path {
+  transition: background-color 260ms ease, background 260ms ease, color 260ms ease, border-color 260ms ease, box-shadow 260ms ease;
+}
+
+body {
+  background:
+    radial-gradient(circle at 10% 10%, color-mix(in srgb, var(--accent), transparent 90%), transparent 28rem),
+    radial-gradient(circle at 90% 0%, color-mix(in srgb, #d98b35, transparent 88%), transparent 22rem),
+    linear-gradient(180deg, var(--bg), color-mix(in srgb, var(--bg), var(--panel) 28%));
+}
+body::before {
+  content: "";
+  position: fixed;
+  inset: -20% -10% auto;
+  height: 26rem;
+  pointer-events: none;
+  background: radial-gradient(circle at 50% 50%, color-mix(in srgb, var(--accent), transparent 88%), transparent 62%);
+  filter: blur(28px);
+  opacity: 0.75;
+  animation: ambient-drift 14s ease-in-out infinite alternate;
+  z-index: -2;
+}
+.site-header { background: var(--surface-glass); }
+.header-actions { display: inline-flex; align-items: center; gap: 0.65rem; }
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  min-height: 2.65rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--panel), transparent 5%);
+  color: var(--ink);
+  padding: 0.38rem 0.72rem 0.38rem 0.42rem;
+  font-weight: 850;
+  cursor: pointer;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.06);
+  transition: transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease, background 180ms ease;
+}
+.theme-toggle:hover { transform: translateY(-1px); border-color: color-mix(in srgb, var(--accent), var(--line) 38%); box-shadow: var(--shadow-soft); }
+.theme-toggle__track { position: relative; width: 2.35rem; height: 1.35rem; border-radius: 999px; background: color-mix(in srgb, var(--accent), var(--panel) 68%); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent), transparent 60%); }
+.theme-toggle__thumb { position: absolute; top: 0.18rem; left: 0.2rem; width: 0.99rem; height: 0.99rem; border-radius: 50%; background: var(--panel-strong); box-shadow: 0 2px 8px rgba(0,0,0,0.2); transition: transform 220ms ease, background 220ms ease; }
+html[data-theme="dark"] .theme-toggle__thumb { transform: translateX(0.96rem); background: var(--accent); }
+
+.brand span, .button, .timeline li::before, .dialog-close, .filters .is-active { color: var(--bg); }
+.hero__lead, .project-card p, .timeline p, .lead, .project-detail__summary p, .project-detail__learned p { color: var(--copy); }
+.hero__chips > span, .filters button, .project-empty, .skill-grid li { background: var(--chip-bg); color: var(--copy); }
+.hero__focus li, .detail-grid section, .project-proof article { background: color-mix(in srgb, var(--panel-strong), transparent 34%); }
+.proof-strip article { position: relative; overflow: hidden; background: linear-gradient(135deg, color-mix(in srgb, var(--panel-strong), transparent 8%), color-mix(in srgb, var(--panel), transparent 18%)); transition: transform 200ms ease, box-shadow 200ms ease, border-color 200ms ease; }
+.proof-strip article::after { content: ""; position: absolute; inset: auto 12% 0; height: 3px; border-radius: 999px 999px 0 0; background: linear-gradient(90deg, transparent, var(--accent), transparent); opacity: 0.6; }
+.proof-strip article:hover { transform: translateY(-3px); border-color: color-mix(in srgb, var(--accent), var(--line) 35%); box-shadow: var(--shadow-card); }
+
+.about { padding-top: clamp(2rem, 5vw, 4.5rem); }
+.about__card { display: grid; grid-template-columns: minmax(0, 1.35fr) minmax(18rem, 0.65fr); gap: clamp(1.25rem, 3vw, 2rem); width: var(--wrap); max-width: 100%; margin-inline: auto; padding: clamp(1.3rem, 3vw, 2.4rem); border: 1px solid var(--line); border-radius: var(--radius-lg); background: linear-gradient(135deg, color-mix(in srgb, var(--panel-strong), transparent 4%), color-mix(in srgb, var(--panel), transparent 14%)); box-shadow: var(--shadow-soft); }
+.about__content h2 { max-width: 56rem; margin: 0 0 1rem; font-size: clamp(2rem, 4.5vw, 4rem); line-height: 1; letter-spacing: -0.05em; }
+.about__lead { color: var(--copy); font-size: clamp(1.05rem, 1.8vw, 1.25rem); }
+.about__content p { margin: 0.85rem 0 0; color: var(--copy-soft); }
+.about__points { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.75rem; padding: 0; margin: 1.35rem 0 0; list-style: none; }
+.about__points li { display: flex; align-items: center; gap: 0.65rem; border: 1px solid var(--line); border-radius: 1rem; padding: 0.7rem; background: color-mix(in srgb, var(--panel-strong), transparent 32%); font-weight: 850; }
+.about__path { align-self: stretch; border: 1px solid color-mix(in srgb, var(--accent), var(--line) 55%); border-radius: 1.15rem; padding: 1.1rem; background: color-mix(in srgb, var(--accent), var(--panel) 88%); }
+.about__path strong { display: block; font-size: 1.35rem; letter-spacing: -0.03em; }
+.about__path > span { display: block; color: var(--muted); font-weight: 800; }
+.about__path ol { display: grid; gap: 0.8rem; padding-left: 1.15rem; margin: 1.2rem 0 0; color: var(--copy); }
+
+.project-card::after { content: ""; position: absolute; inset: 0; pointer-events: none; background: linear-gradient(120deg, transparent 20%, color-mix(in srgb, var(--accent), transparent 90%) 42%, transparent 62%); opacity: 0; transform: translateX(-35%); transition: opacity 220ms ease, transform 520ms ease; }
+.project-card:hover::after { opacity: 1; transform: translateX(35%); }
+.project-visual { transition: transform 360ms ease, filter 260ms ease; }
+.project-card:hover .project-visual::before { animation: visual-pulse 1.8s ease-in-out infinite alternate; }
+.text-link, .nav-link { transition: color 180ms ease, background 180ms ease, border-color 180ms ease, transform 180ms ease, text-decoration-color 180ms ease; }
+.text-link:hover { text-decoration-color: color-mix(in srgb, var(--accent), var(--ink) 25%); }
+
+.hero__focus li b { display: flex; align-items: center; min-width: 0; }
+.hero__focus li > span { display: block; }
+.icon-badge { overflow: hidden; }
+
+.theme-paint {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  pointer-events: none;
+  color: var(--paint-color);
+  transform: translateY(-112%);
+  animation: paint-drop 820ms cubic-bezier(.72, 0, .2, 1) forwards;
+}
+.theme-paint[data-theme-paint="dark"] { color: #0b1110; }
+.theme-paint[data-theme-paint="light"] { color: #f5f1e8; }
+.theme-paint::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 16%;
+  background: currentColor;
+  border-radius: 0 0 42% 36% / 0 0 9% 11%;
+  box-shadow: 0 28px 60px rgba(0,0,0,0.18);
+}
+.theme-paint span { position: absolute; top: 66%; left: calc(7% + var(--drip-index) * 14%); width: clamp(3.4rem, 10vw, 8rem); height: clamp(4rem, 16vw, 12rem); border-radius: 999px; background: currentColor; filter: drop-shadow(0 18px 16px rgba(0,0,0,0.09)); }
+.theme-paint span:nth-child(2n) { width: clamp(2.5rem, 7vw, 5.8rem); height: clamp(5rem, 19vw, 14rem); transform: translateY(1.6rem); }
+.theme-paint span:nth-child(3n) { top: 61%; transform: translateY(3.1rem); }
+.theme-paint.is-finished { animation: paint-exit 360ms ease-in forwards; }
+
+@keyframes paint-drop { 0% { transform: translateY(-112%); } 58% { transform: translateY(-8%); } 100% { transform: translateY(0); } }
+@keyframes paint-exit { from { opacity: 1; transform: translateY(0); } to { opacity: 0; transform: translateY(6%); } }
+@keyframes ambient-drift { from { transform: translate3d(-2%, -1%, 0) scale(1); } to { transform: translate3d(4%, 2%, 0) scale(1.08); } }
+@keyframes visual-pulse { from { transform: translate3d(0, 0, 0) scale(1); } to { transform: translate3d(-0.6rem, 0.4rem, 0) scale(1.04); } }
+
+@media (max-width: 800px) {
+  .site-header { align-items: center; }
+  .theme-toggle__text { display: none; }
+  .hero__focus { padding: 1.1rem; }
+  .hero__focus ul { gap: 0.82rem; margin-top: 1.15rem; }
+  .hero__focus li { display: grid; gap: 0.45rem; padding: 0.92rem; }
+  .hero__focus li b { align-items: center; gap: 0.68rem; font-size: 0.98rem; line-height: 1.18; }
+  .hero__focus li span:not(.icon-badge) { margin-top: 0; padding-left: 0; font-size: 0.9rem; line-height: 1.5; }
+  .hero__focus .icon-badge--lg { --icon-badge-size: 2.35rem; --icon-in-badge-size: 1.18rem; --icon-badge-radius: 0.82rem; }
+  .about__card { grid-template-columns: 1fr; }
+  .about__points { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 420px) {
+  .brand strong { display: none; }
+  .hero__focus .icon-badge--lg { --icon-badge-size: 2.25rem; --icon-in-badge-size: 1.1rem; }
+  .hero__focus li { padding: 0.85rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body::before { animation: none; }
+  .theme-paint { display: none; }
+  .proof-strip article:hover, .theme-toggle:hover { transform: none; }
+  .project-card:hover::after { opacity: 0; }
+}


### PR DESCRIPTION
### Motivation
- Rendre la zone “Focus 2026” lisible et équilibrée sur mobile en stabilisant l’alignement des titres, badges et icônes. 
- Introduire une section « À propos de moi » professionnelle et concise pour positionner le profil hybride Java/Angular + Data/BI. 
- Apporter une expérience visuelle premium : thème clair/sombre persistant, transition soignée de changement de thème et micro‑interactions tout en respectant `prefers-reduced-motion`.

### Description
- Ajout d’un bloc `about` structuré dans `src/data/portfolioData.ts` et insertion de la section “À propos” dans `src/pages/index.astro` (placée après le hero/proof-strip et avant les case studies). 
- Toggle de thème accessible inséré dans le header via `src/components/Header.astro` avec `aria-label` et `aria-pressed`, et initialisation du `data-theme` sur `<html>` au premier rendu via un script inline dans `src/pages/index.astro` qui respecte `localStorage` et `prefers-color-scheme`. 
- Gestion JS du thème et de l’animation « peinture qui dégouline » ajoutée dans `public/scripts/main.js` (persistence, detection système, overlay dynamique, respect de `prefers-reduced-motion`). 
- Variables CSS tokens et styles dark mode ajoutés dans `src/styles/global.css`, adaptation des surfaces/cartes/proof-strip/footer/aside, règles mobiles pour `.hero__focus` et `icon-badge` (taille badges ~2.25–2.35rem, icônes internes ~1.1–1.18rem) et animation de transition optimisée pour la performance.

### Testing
- Installation des dépendances avec `npm ci --no-audit --no-fund` — commande exécutée avec succès. 
- Build statique effectué avec `ASTRO_TELEMETRY_DISABLED=1 npm run build` — build réussi (3 page(s) générées). 
- Recherches de vérification exécutées avec `rg -n "data-theme|theme-paint|localStorage|prefers-color-scheme|prefers-reduced-motion" src public` et `rg -n 'href="/|src="/' src` — entrées thématiques trouvées et aucun chemin absolu problématique détecté. 
- Différence de travail vérifiée via `git diff --numstat` montrant les fichiers modifiés (`public/scripts/main.js`, `src/styles/global.css`, `src/pages/index.astro`, `src/data/portfolioData.ts`, `src/components/Header.astro`); tentative d’aperçu automatisé (playwright / navigateur headless) non possible car aucun navigateur headless n’est présent dans l’environnement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a494b63a518832c95683e5883641a32)