### PR TITLE
Clarify Java versions and Docker/CI proofing for JLH AutoPam & Locatech

### DIFF
--- a/src/components/ProjectDetails.astro
+++ b/src/components/ProjectDetails.astro
@@ -45,8 +45,8 @@ const hasLinks = Boolean(links.repo || links.demo || docs.length);
     {hasProof && (
       <section class="project-proof" aria-label="Ce projet démontre">
         <div>
-          <p class="eyebrow">Ce projet démontre</p>
-          <h4>Une lecture claire des preuves projet</h4>
+          <p class="eyebrow">Preuves techniques</p>
+          <h4>Repères vérifiables du projet</h4>
         </div>
         <div class="project-proof__grid">
           {project.highlights.length > 0 && <article><h5>Points clés</h5><ul>{project.highlights.map((item) => <li>{item}</li>)}</ul></article>}

--- a/src/components/ProjectVisual.astro
+++ b/src/components/ProjectVisual.astro
@@ -27,7 +27,7 @@ const panelKinds = ['dashboard', 'data', 'app', 'tool', 'document'];
 
     {visual.kind === 'pipeline' && (
       <div class="visual-pipeline" aria-hidden="true">
-        <span>GitHub</span><i></i><span>Build</span><i></i><span>Docker Hub</span><i></i><span>Hostinger</span>
+        <span>Front/back</span><i></i><span>Images</span><i></i><span>Docker Hub</span><i></i><span>Hostinger</span>
       </div>
     )}
 

--- a/src/data/portfolioData.ts
+++ b/src/data/portfolioData.ts
@@ -103,8 +103,8 @@ export const projectCategories: { id: ProjectCategory; label: string; icon: stri
 
 export const capabilities = [
   { title: 'Applications métier', icon: 'app', text: 'Transformer un besoin terrain en parcours utilisateur, règles métier et écrans utiles.' },
-  { title: 'APIs sécurisées', icon: 'api', text: 'Structurer des backends Java 21/Spring Boot, authentification JWT, rôles et modèles relationnels.' },
-  { title: 'CI/CD & conteneurisation', icon: 'tools', text: 'Dockeriser les fronts et backends, automatiser les contrôles GitHub Actions, publier les images et préparer des déploiements reproductibles.' },
+  { title: 'APIs sécurisées', icon: 'api', text: 'Structurer des backends Java/Spring Boot, authentification JWT, rôles et modèles relationnels.' },
+  { title: 'CI/CD & conteneurisation', icon: 'tools', text: 'Dockeriser les fronts et backends, préparer l’automatisation GitHub Actions, publier les images et documenter des déploiements reproductibles.' },
   { title: 'Données propres', icon: 'database', text: 'Nettoyer, consolider, contrôler et documenter des jeux de données exploitables.' },
   { title: 'Restitution décisionnelle', icon: 'dashboard', text: 'Construire des indicateurs, dashboards et analyses orientés action.' }
 ];
@@ -115,7 +115,7 @@ export const skills = [
   { group: 'Frontend', icon: 'frontend', items: ['TypeScript', 'JavaScript', 'HTML/CSS', 'SCSS', 'Styled-components', 'Accessibilité'] },
   { group: 'Data / BI', icon: 'data-bi', items: ['SQL', 'Python', 'pandas', 'numpy', 'Jupyter', 'matplotlib', 'seaborn', 'Excel'] },
   { group: 'Qualité / méthode', icon: 'quality', items: ['Modélisation', 'RGPD', 'Documentation', 'Contrôle qualité', 'Responsive', 'Git'] },
-  { group: 'Outils', icon: 'tools', items: ['Docker', 'Docker Compose', 'GitHub Actions', 'Docker Hub', 'CI/CD', 'Déploiement Hostinger', 'GitHub Pages'] }
+  { group: 'Outils', icon: 'tools', items: ['Docker', 'Docker Compose', 'GitHub Actions', 'Docker Hub', 'CI/CD', 'Hostinger', 'GitHub Pages'] }
 ];
 
 export const journey = [
@@ -131,19 +131,19 @@ const placeholderImage = cardImage;
 export const projects: Project[] = [
   {
     id: 'jlh-autopam', title: 'JLH AutoPam', shortTitle: 'Garage connecté', category: 'fullstack', featured: true,
-    status: 'En cours / projet vitrine', period: '2026', role: 'Développeur fullstack', image: placeholderImage, imageAlt: 'Chaîne applicative JLH AutoPam générée en CSS', visual: { kind: 'pipeline', eyebrow: 'Garage · CI/CD', title: 'Front/back → Docker Hub → Hostinger', metrics: ['Angular SSR', 'Containers front/back', 'GitHub Actions'] }, accent: '#2d7f82',
-    stack: ['Angular 20', 'Angular SSR', 'TypeScript', 'SCSS', 'Spring Boot 3.5', 'Java 21', 'PostgreSQL', 'JWT', 'Docker', 'GitHub Actions', 'Docker Hub', 'Hostinger', 'CI/CD'],
-    skills: ['Architecture front/back', 'API REST sécurisée', 'Authentification JWT', 'Rôles client/admin', 'Dockerisation', 'Pipeline CI/CD'],
-    summary: 'Application métier fullstack pour garage automobile, avec espace client, back-office, API sécurisée et chaîne CI/CD containerisée jusqu’au déploiement Hostinger.',
+    status: 'En cours / projet vitrine', period: '2026', role: 'Développeur fullstack & pipeline CI/CD', image: placeholderImage, imageAlt: 'Chaîne applicative JLH AutoPam générée en CSS', visual: { kind: 'pipeline', eyebrow: 'Garage · Docker', title: 'Front/back → Docker Hub → Hostinger', metrics: ['Angular SSR', 'Containers front/back', 'Compose production'] }, accent: '#2d7f82',
+    stack: ['Angular 20', 'Angular SSR', 'TypeScript', 'SCSS', 'Spring Boot 3.5', 'Java 17', 'PostgreSQL', 'JWT', 'Docker', 'GitHub Actions', 'Docker Hub', 'Hostinger', 'CI/CD'],
+    skills: ['Architecture front/back', 'API REST sécurisée', 'Authentification JWT', 'Rôles client/admin', 'Dockerisation', 'Démarche CI/CD Docker'],
+    summary: 'Application métier fullstack pour garage automobile, avec espace client, back-office, API sécurisée, containers front/back et chaîne de livraison Docker jusqu’à Hostinger.',
     context: 'Projet vitrine orienté garage automobile : l’objectif est de relier les demandes client, le suivi administratif, les devis et les rendez-vous dans une même application web.',
     problem: 'Centraliser les demandes clients, les services, les rendez-vous et la gestion administrative dans une application unique, sans perdre la séparation entre usages client et back-office.',
-    solution: 'Frontend Angular 20 avec SSR, API Spring Boot 3.5 en Java 21, authentification JWT, rôles client/admin, persistance PostgreSQL et containers front/back reliés à une chaîne de livraison GitHub Actions → Docker Hub → Hostinger.',
-    deliverables: ['Espace client', 'Administration / back-office', 'Gestion demandes / devis / rendez-vous', 'API REST sécurisée avec JWT', 'Containers Docker front/back', 'Chaîne de livraison GitHub Actions → Docker Hub → Hostinger'],
-    decisions: ['Angular SSR pour disposer d’un front moderne, routé et prêt pour une diffusion web plus robuste', 'Spring Boot 3.5 / Java 21 pour structurer les règles métier et l’API REST', 'JWT et rôles pour séparer les parcours client et administration', 'Dockeriser front et back pour rendre le déploiement reproductible', 'Publier les images validées vers Docker Hub avant déploiement des containers sur Hostinger'],
-    learned: 'Renforcement de la conception fullstack de bout en bout : découpage front/back, sécurité JWT, workflow métier, containers applicatifs et chaîne de publication contrôlée.',
-    impact: 'Projet le plus représentatif de mon profil fullstack actuel : application métier, API sécurisée, Dockerisation et démarche CI/CD concrète.',
-    highlights: ['Pipeline GitHub Actions → Docker Hub → Hostinger', 'Containers front/back', 'Contrôles avant publication', 'Déploiement reproductible', 'Espace client', 'Back-office'],
-    metrics: ['Angular 20 + SSR', 'Spring Boot 3.5 / Java 21', 'PostgreSQL', 'API REST sécurisée', 'Docker Hub', 'Hostinger'],
+    solution: 'Frontend Angular 20 avec SSR, API Spring Boot 3.5 en Java 17, authentification JWT, rôles client/admin, persistance PostgreSQL et containers front/back reliés à une chaîne Docker documentée pour publication et déploiement, avec objectif CI/CD GitHub Actions → Docker Hub → Hostinger.',
+    deliverables: ['Espace client', 'Administration / back-office', 'Gestion demandes / devis / rendez-vous', 'API REST sécurisée avec JWT', 'Containers Docker front/back', 'Chaîne Docker documentée pour publication et déploiement vers Docker Hub / Hostinger'],
+    decisions: ['Angular SSR pour disposer d’un front moderne, routé et prêt pour une diffusion web plus robuste', 'Spring Boot 3.5 / Java 17 pour structurer les règles métier et l’API REST', 'JWT et rôles pour séparer les parcours client et administration', 'Dockeriser front et back pour rendre le déploiement reproductible', 'Préparer la publication des images backend/frontend vers Docker Hub avant déploiement des containers sur Hostinger via docker-compose.hostinger.yml'],
+    learned: 'Renforcement de la conception fullstack de bout en bout : découpage front/back, sécurité JWT, workflow métier, containers applicatifs et chaîne de livraison Docker documentée.',
+    impact: 'Projet le plus représentatif de mon profil fullstack actuel : application métier, API sécurisée, Dockerisation et démarche Docker / CI-CD documentée.',
+    highlights: ['Backend image Docker', 'Frontend image Docker', 'Docker Hub', 'Hostinger', 'PostgreSQL', 'Compose production'],
+    metrics: ['Angular 20 + SSR', 'Spring Boot 3.5 / Java 17', 'docker-compose.hostinger.yml', 'API REST sécurisée', 'Déploiement reproductible', 'Images backend/frontend'],
     links: { repo: 'https://github.com/steve57000/jlh' }
   },
   {
@@ -215,20 +215,21 @@ export const projects: Project[] = [
   },
 
   {
+    // TODO: harmoniser source/target Java 21 dans le repository Locatech
     id: 'locatech', title: 'Locatech', shortTitle: 'Location matériel', category: 'fullstack', featured: true,
     status: 'Projet MNS / application métier', period: 'Formation MNS', role: 'Développement fullstack / architecture applicative', image: placeholderImage, imageAlt: 'Architecture multi-services Locatech générée en CSS', visual: { kind: 'docker', eyebrow: 'Java 21 / Angular', title: 'Location matériel multi-services', metrics: ['Docker Compose', 'MySQL + MongoDB', 'API catégories'] }, accent: '#3b6f8f',
     stack: ['Angular', 'TypeScript', 'SCSS', 'Spring Boot', 'Java 21', 'MySQL', 'MongoDB', 'Docker Compose'],
     skills: ['Architecture front/back', 'API REST', 'Données relationnelles', 'Données documentaires', 'Orchestration multi-services', 'Conteneurisation'],
-    summary: 'Application métier fullstack de location de matériel, avec frontend Angular, backend Spring Boot Java 21, bases MySQL/MongoDB et orchestration Docker Compose.',
+    summary: 'Application métier fullstack de location de matériel, avec frontend Angular, API Spring Boot, bases MySQL/MongoDB et orchestration Docker Compose.',
     context: 'Projet MNS organisé autour d’un besoin de location de matériel : catalogue, catégories, disponibilité et historique des équipements, avec une séparation claire entre interface Angular et API Spring Boot.',
     problem: 'Outiller un processus de location de matériel avec gestion de catalogue, disponibilité et historique, plutôt que disperser les informations entre fichiers ou services isolés.',
     solution: 'Architecture front/back séparée : Angular côté interface, Spring Boot côté API REST, MySQL pour les données métier, MongoDB pour l’historique matériel et Docker Compose pour orchestrer les services en local.',
     deliverables: ['Frontend Angular', 'Backend Java Spring Boot', 'API REST avec endpoints catégories', 'Historique matériel', 'Bases MySQL et MongoDB', 'Orchestration Docker Compose multi-services'],
-    decisions: ['Séparer clairement le frontend Angular et le backend Spring Boot', 'Utiliser MySQL pour les données relationnelles de location', 'Ajouter MongoDB pour l’historique des équipements', 'S’appuyer sur Docker Compose pour rendre l’environnement multi-services reproductible'],
+    decisions: ['Séparer clairement le frontend Angular et le backend Spring Boot', 'Combiner MySQL pour les données relationnelles métier et MongoDB pour l’historique matériel', 'Exposer une API catégories côté backend', 'S’appuyer sur Docker Compose pour rendre l’environnement multi-services reproductible'],
     learned: 'Conception d’une application métier complète : découpage front/back, configuration d’environnements, persistance SQL/NoSQL et exposition d’endpoints REST vérifiables.',
     impact: 'Renforce le positionnement Java / Angular avec un projet applicatif sérieux, centré sur un besoin métier identifiable et une orchestration technique vérifiable.',
-    highlights: ['Développement fullstack', 'Architecture applicative', 'API catégories', 'Historique matériel', 'MySQL + MongoDB', 'Docker Compose'],
-    metrics: ['Orchestration multi-services', 'Backend Spring Boot Java 21', 'Frontend Angular', 'Persistance SQL/NoSQL'],
+    highlights: ['Front Angular', 'API Spring Boot', 'MySQL', 'MongoDB', 'Docker Compose', 'API catégories'],
+    metrics: ['Orchestration multi-services', 'Séparation front/back', 'Historique matériel', 'Persistance SQL/NoSQL'],
     links: { repo: 'https://github.com/steve57000/Locatech' }
   },
   {


### PR DESCRIPTION
### Motivation
- Align the portfolio text with the actual Java/runtime evidence found in the repositories so the site does not assert unsupported runtime versions. 
- Preserve and strengthen the technical presentation of JLH AutoPam as a fullstack + CI/CD-capable project while avoiding an incorrect claim of Java 21. 
- Clarify Locatech as a multi-service Angular/Spring Boot project and record an internal TODO to harmonize Maven `source`/`target` in the repo without exposing noisy details in the UI.

### Description
- Updated `src/data/portfolioData.ts` to replace JLH AutoPam `Java 21` mentions with `Java 17` and to rephrase stack, summary, decisions, deliverables, highlights and metrics to emphasise containerised front/back images, `docker-compose.hostinger.yml`, Docker Hub and Hostinger deployment goals rather than asserting executed CI runs. 
- Added an internal comment `// TODO: harmoniser source/target Java 21 dans le repository Locatech` in `src/data/portfolioData.ts` and softened Locatech wording to `API Spring Boot` / generic `Java` markers while explicitly documenting the recommended technical decision to combine MySQL (relational) and MongoDB (historical data). 
- Adjusted global wording to avoid over‑claims: changed the capabilities text to `Java/Spring Boot` (no hard `Java 21` assertion) and updated the tools list formatting. 
- Improved the proof presentation: renamed project proof header to “Preuves techniques” in `src/components/ProjectDetails.astro` and changed the pipeline visual in `src/components/ProjectVisual.astro` to emphasise `Front/back` → `Images` → `Docker Hub` → `Hostinger` rather than implying a specific verified GitHub build step.

### Testing
- Ran `npm ci --no-audit --no-fund` and package install completed successfully. 
- Built the site with `ASTRO_TELEMETRY_DISABLED=1 npm run build` and the Astro build succeeded (static pages generated). 
- Searched the codebase with ripgrep for key terms (`Java 21|Java 17|GitHub Actions|Docker Hub|Hostinger|JLH AutoPam|Locatech`) to confirm updates; results now reflect the revised wording and no remaining JLH Java 21 claims. 
- Searched workspace for Maven/Java compilation flags (`java.version|source>|target>`) and found no local repo files to contradict the portfolio (external repositories were not present locally), so an internal TODO comment was added for Locatech. 
- Verified no binary files were added or modified and the site build remains green.
