### PR TITLE
Finition données projet et hiérarchie des preuves techniques

### DIFF
--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -5,6 +5,7 @@ import type { Project } from '../data/portfolioData';
 
 const { project, index = 0 } = Astro.props as { project: Project; index?: number };
 const links = project.links ?? {};
+const visibleStackCount = project.featured ? 6 : 5;
 ---
 <article class:list={["project-card", project.featured && "is-featured"]} data-project-card data-reveal data-category={project.category} style={`--accent:${project.accent};--reveal-delay:${Math.min(index % 4, 3) * 80}ms`}>
   <div class="project-card__media">
@@ -22,7 +23,7 @@ const links = project.links ?? {};
     <h3>{project.title}</h3>
     <p>{project.summary}</p>
     <ul class="tags" aria-label={`Technologies ${project.title}`}>
-      {project.stack.slice(0, 5).map((item) => <li>{item}</li>)}
+      {project.stack.slice(0, visibleStackCount).map((item) => <li>{item}</li>)}
     </ul>
     <div class="project-card__actions">
       <button class="button button--ghost" type="button" data-project-open={project.id}><Icon name="details" />Détails</button>

--- a/src/components/ProjectDetails.astro
+++ b/src/components/ProjectDetails.astro
@@ -47,11 +47,12 @@ const hasLinks = Boolean(links.repo || links.demo || docs.length);
         <div>
           <p class="eyebrow">Preuves techniques</p>
           <h4>Repères vérifiables du projet</h4>
+          <p class="project-proof__intro">Éléments concrets visibles dans le dépôt, la structure du projet ou les livrables.</p>
         </div>
         <div class="project-proof__grid">
-          {project.highlights.length > 0 && <article><h5>Points clés</h5><ul>{project.highlights.map((item) => <li>{item}</li>)}</ul></article>}
+          {project.highlights.length > 0 && <article><h5>Preuves projet</h5><ul>{project.highlights.map((item) => <li>{item}</li>)}</ul></article>}
           {project.skills.length > 0 && <article><h5><span class="icon-badge icon-badge--sm"><Icon name="stack" /></span>Compétences mobilisées</h5><ul>{project.skills.map((item) => <li>{item}</li>)}</ul></article>}
-          {project.metrics.length > 0 && <article><h5><span class="icon-badge icon-badge--sm"><Icon name="metrics" /></span>Repères techniques</h5><ul>{project.metrics.map((item) => <li>{item}</li>)}</ul></article>}
+          {project.metrics.length > 0 && <article><h5><span class="icon-badge icon-badge--sm"><Icon name="metrics" /></span>Stack vérifiable</h5><ul>{project.metrics.map((item) => <li>{item}</li>)}</ul></article>}
         </div>
       </section>
     )}

--- a/src/components/ProjectVisual.astro
+++ b/src/components/ProjectVisual.astro
@@ -33,7 +33,7 @@ const panelKinds = ['dashboard', 'data', 'app', 'tool', 'document'];
 
     {visual.kind === 'docker' && (
       <div class="visual-docker" aria-hidden="true">
-        <span>Front</span><span>API</span><span>MySQL</span><span>MongoDB</span>
+        <span>Angular</span><span>API</span><span>MySQL</span><span>MongoDB</span>
       </div>
     )}
 

--- a/src/data/portfolioData.ts
+++ b/src/data/portfolioData.ts
@@ -131,17 +131,17 @@ const placeholderImage = cardImage;
 export const projects: Project[] = [
   {
     id: 'jlh-autopam', title: 'JLH AutoPam', shortTitle: 'Garage connecté', category: 'fullstack', featured: true,
-    status: 'En cours / projet vitrine', period: '2026', role: 'Développeur fullstack & pipeline CI/CD', image: placeholderImage, imageAlt: 'Chaîne applicative JLH AutoPam générée en CSS', visual: { kind: 'pipeline', eyebrow: 'Garage · Docker', title: 'Front/back → Docker Hub → Hostinger', metrics: ['Angular SSR', 'Containers front/back', 'Compose production'] }, accent: '#2d7f82',
-    stack: ['Angular 20', 'Angular SSR', 'TypeScript', 'SCSS', 'Spring Boot 3.5', 'Java 17', 'PostgreSQL', 'JWT', 'Docker', 'GitHub Actions', 'Docker Hub', 'Hostinger', 'CI/CD'],
-    skills: ['Architecture front/back', 'API REST sécurisée', 'Authentification JWT', 'Rôles client/admin', 'Dockerisation', 'Démarche CI/CD Docker'],
-    summary: 'Application métier fullstack pour garage automobile, avec espace client, back-office, API sécurisée, containers front/back et chaîne de livraison Docker jusqu’à Hostinger.',
+    status: 'En cours / projet vitrine', period: '2026', role: 'Développeur fullstack & préparation CI/CD', image: placeholderImage, imageAlt: 'Chaîne applicative JLH AutoPam générée en CSS', visual: { kind: 'pipeline', eyebrow: 'Garage · Docker', title: 'Front/back → Docker Hub → Hostinger', metrics: ['Angular SSR', 'Containers front/back', 'Compose production'] }, accent: '#2d7f82',
+    stack: ['Angular 20', 'Angular SSR', 'TypeScript', 'SCSS', 'Spring Boot 3.5', 'Java 17', 'PostgreSQL', 'JWT', 'Docker', 'Docker Hub', 'Hostinger'],
+    skills: ['Architecture front/back', 'API REST sécurisée', 'Authentification JWT', 'Rôles client/admin', 'Dockerisation', 'Préparation CI/CD'],
+    summary: 'Projet applicatif métier pour garage automobile : front/back Angular et Spring Boot, sécurité JWT, PostgreSQL, Docker et déploiement reproductible vers Hostinger.',
     context: 'Projet vitrine orienté garage automobile : l’objectif est de relier les demandes client, le suivi administratif, les devis et les rendez-vous dans une même application web.',
     problem: 'Centraliser les demandes clients, les services, les rendez-vous et la gestion administrative dans une application unique, sans perdre la séparation entre usages client et back-office.',
-    solution: 'Frontend Angular 20 avec SSR, API Spring Boot 3.5 en Java 17, authentification JWT, rôles client/admin, persistance PostgreSQL et containers front/back reliés à une chaîne Docker documentée pour publication et déploiement, avec objectif CI/CD GitHub Actions → Docker Hub → Hostinger.',
-    deliverables: ['Espace client', 'Administration / back-office', 'Gestion demandes / devis / rendez-vous', 'API REST sécurisée avec JWT', 'Containers Docker front/back', 'Chaîne Docker documentée pour publication et déploiement vers Docker Hub / Hostinger'],
+    solution: 'Frontend Angular 20 avec SSR, API Spring Boot 3.5 en Java 17, authentification JWT, rôles client/admin, persistance PostgreSQL et containers front/back reliés à une chaîne Docker documentée, avec préparation CI/CD et objectif de pipeline GitHub Actions vers Docker Hub puis Hostinger.',
+    deliverables: ['Espace client', 'Administration / back-office', 'Gestion demandes / devis / rendez-vous', 'API REST sécurisée avec JWT', 'Containers Docker front/back', 'Chaîne Docker documentée pour publication et déploiement reproductible Docker Hub / Hostinger'],
     decisions: ['Angular SSR pour disposer d’un front moderne, routé et prêt pour une diffusion web plus robuste', 'Spring Boot 3.5 / Java 17 pour structurer les règles métier et l’API REST', 'JWT et rôles pour séparer les parcours client et administration', 'Dockeriser front et back pour rendre le déploiement reproductible', 'Préparer la publication des images backend/frontend vers Docker Hub avant déploiement des containers sur Hostinger via docker-compose.hostinger.yml'],
-    learned: 'Renforcement de la conception fullstack de bout en bout : découpage front/back, sécurité JWT, workflow métier, containers applicatifs et chaîne de livraison Docker documentée.',
-    impact: 'Projet le plus représentatif de mon profil fullstack actuel : application métier, API sécurisée, Dockerisation et démarche Docker / CI-CD documentée.',
+    learned: 'Renforcement de la conception fullstack de bout en bout : découpage front/back, sécurité JWT, workflow métier garage, containers applicatifs et chaîne Docker documentée.',
+    impact: 'Projet le plus représentatif de mon profil fullstack actuel : garage automobile, API sécurisée, PostgreSQL, Dockerisation et déploiement reproductible Docker Hub / Hostinger.',
     highlights: ['Backend image Docker', 'Frontend image Docker', 'Docker Hub', 'Hostinger', 'PostgreSQL', 'Compose production'],
     metrics: ['Angular 20 + SSR', 'Spring Boot 3.5 / Java 17', 'docker-compose.hostinger.yml', 'API REST sécurisée', 'Déploiement reproductible', 'Images backend/frontend'],
     links: { repo: 'https://github.com/steve57000/jlh' }
@@ -215,19 +215,18 @@ export const projects: Project[] = [
   },
 
   {
-    // TODO: harmoniser source/target Java 21 dans le repository Locatech
     id: 'locatech', title: 'Locatech', shortTitle: 'Location matériel', category: 'fullstack', featured: true,
     status: 'Projet MNS / application métier', period: 'Formation MNS', role: 'Développement fullstack / architecture applicative', image: placeholderImage, imageAlt: 'Architecture multi-services Locatech générée en CSS', visual: { kind: 'docker', eyebrow: 'Java 21 / Angular', title: 'Location matériel multi-services', metrics: ['Docker Compose', 'MySQL + MongoDB', 'API catégories'] }, accent: '#3b6f8f',
     stack: ['Angular', 'TypeScript', 'SCSS', 'Spring Boot', 'Java 21', 'MySQL', 'MongoDB', 'Docker Compose'],
     skills: ['Architecture front/back', 'API REST', 'Données relationnelles', 'Données documentaires', 'Orchestration multi-services', 'Conteneurisation'],
-    summary: 'Application métier fullstack de location de matériel, avec frontend Angular, API Spring Boot, bases MySQL/MongoDB et orchestration Docker Compose.',
+    summary: 'Projet d’architecture applicative pour la location de matériel : Angular + Spring Boot, MySQL + MongoDB, Docker Compose, API catégories et historique matériel.',
     context: 'Projet MNS organisé autour d’un besoin de location de matériel : catalogue, catégories, disponibilité et historique des équipements, avec une séparation claire entre interface Angular et API Spring Boot.',
     problem: 'Outiller un processus de location de matériel avec gestion de catalogue, disponibilité et historique, plutôt que disperser les informations entre fichiers ou services isolés.',
     solution: 'Architecture front/back séparée : Angular côté interface, Spring Boot côté API REST, MySQL pour les données métier, MongoDB pour l’historique matériel et Docker Compose pour orchestrer les services en local.',
     deliverables: ['Frontend Angular', 'Backend Java Spring Boot', 'API REST avec endpoints catégories', 'Historique matériel', 'Bases MySQL et MongoDB', 'Orchestration Docker Compose multi-services'],
     decisions: ['Séparer clairement le frontend Angular et le backend Spring Boot', 'Combiner MySQL pour les données relationnelles métier et MongoDB pour l’historique matériel', 'Exposer une API catégories côté backend', 'S’appuyer sur Docker Compose pour rendre l’environnement multi-services reproductible'],
     learned: 'Conception d’une application métier complète : découpage front/back, configuration d’environnements, persistance SQL/NoSQL et exposition d’endpoints REST vérifiables.',
-    impact: 'Renforce le positionnement Java / Angular avec un projet applicatif sérieux, centré sur un besoin métier identifiable et une orchestration technique vérifiable.',
+    impact: 'Renforce le positionnement architecture applicative Java / Angular avec un cas location de matériel, une persistance SQL/NoSQL et une orchestration Docker Compose vérifiable.',
     highlights: ['Front Angular', 'API Spring Boot', 'MySQL', 'MongoDB', 'Docker Compose', 'API catégories'],
     metrics: ['Orchestration multi-services', 'Séparation front/back', 'Historique matériel', 'Persistance SQL/NoSQL'],
     links: { repo: 'https://github.com/steve57000/Locatech' }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -127,7 +127,7 @@ button, a { outline-offset: 4px; }
 }
 .hero h1 { margin: 0; font-size: clamp(3.2rem, 10vw, 8rem); line-height: 0.9; letter-spacing: -0.08em; }
 .hero h1 span { display: block; max-width: 55rem; margin-top: 1rem; font-size: clamp(1.2rem, 2.5vw, 2rem); line-height: 1.2; letter-spacing: -0.02em; }
-.hero__lead { max-width: 56rem; color: #39443f; font-size: clamp(1.2rem, 2vw, 1.7rem); }
+.hero__lead { max-width: 56rem; color: var(--copy); font-size: clamp(1.2rem, 2vw, 1.7rem); }
 .hero__chips { display: flex; flex-wrap: wrap; gap: 0.65rem; margin: 1.4rem 0; }
 .hero__chips > span {
   display: inline-flex;
@@ -204,7 +204,7 @@ button, a { outline-offset: 4px; }
 .project-card__body { display: flex; flex: 1; flex-direction: column; gap: 1.05rem; padding: clamp(1.35rem, 2vw, 1.8rem); }
 .project-card__meta { display: flex; justify-content: space-between; gap: 0.5rem; color: var(--muted); font-size: 0.74rem; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; }
 .project-card h3 { margin: 0; font-size: clamp(1.35rem, 2vw, 1.55rem); line-height: 1.08; letter-spacing: -0.035em; }
-.project-card p { margin: 0; color: #43504a; line-height: 1.65; }
+.project-card p { margin: 0; color: var(--copy-soft); line-height: 1.65; }
 .project-card .tags { margin-top: auto; margin-bottom: 0; padding-top: 0.45rem; padding-bottom: 0.15rem; }
 .project-card:hover { transform: translateY(-4px); border-color: color-mix(in srgb, var(--accent), var(--line) 45%); box-shadow: var(--shadow-hover); }
 .project-card:hover img { transform: scale(1.045); filter: saturate(1.05) contrast(1.03); }
@@ -267,7 +267,7 @@ button, a { outline-offset: 4px; }
 .timeline li::before { content: counter(journey, decimal-leading-zero); display: grid; place-items: center; width: 2.15rem; height: 2.15rem; margin-bottom: 1rem; border-radius: 50%; background: var(--dark); color: #f4d7a1; font-size: 0.78rem; font-weight: 900; box-shadow: 0 0 0 7px color-mix(in srgb, var(--accent), transparent 86%); }
 .timeline span { display: inline-flex; margin-bottom: 0.45rem; color: var(--accent); font-size: 0.82rem; font-weight: 900; letter-spacing: 0.08em; text-transform: uppercase; }
 .timeline h3 { margin: 0 0 0.35rem; letter-spacing: -0.025em; }
-.timeline p { margin: 0; color: #43504a; }
+.timeline p { margin: 0; color: var(--copy-soft); }
 .timeline li:hover { transform: translateY(-3px); border-color: color-mix(in srgb, var(--accent), var(--line) 40%); box-shadow: var(--shadow-card); }
 
 /* dialog */
@@ -279,11 +279,12 @@ button, a { outline-offset: 4px; }
 .dialog-close:hover { transform: rotate(4deg) scale(1.03); background: color-mix(in srgb, var(--accent), var(--dark) 45%); }
 .project-detail__header { max-width: 52rem; padding-right: 3rem; }
 .project-dialog__panel h3 { margin: 0; font-size: clamp(2rem, 5vw, 4rem); line-height: 0.96; letter-spacing: -0.055em; }
-.lead { color: #39443f; font-size: clamp(1.05rem, 2vw, 1.28rem); }
+.lead { color: var(--copy); font-size: clamp(1.05rem, 2vw, 1.28rem); }
 .project-detail__summary, .project-detail__learned, .project-proof, .project-detail__stack { margin-top: 1rem; padding: clamp(1rem, 2vw, 1.25rem); border: 1px solid var(--line); border-radius: 1.05rem; background: linear-gradient(135deg, rgba(255,255,255,0.66), rgba(255,248,234,0.54)); }
 .project-detail__summary { display: grid; gap: 0.35rem; border-left: 5px solid var(--accent); }
 .project-detail__summary span { color: var(--accent); font-weight: 900; letter-spacing: 0.08em; text-transform: uppercase; }
-.project-detail__summary p, .project-detail__learned p { margin: 0; color: #43504a; }
+.project-detail__summary p, .project-detail__learned p { margin: 0; color: var(--copy-soft); }
+.project-proof__intro { max-width: 52rem; margin: 0.3rem 0 0; color: var(--copy-soft); line-height: 1.55; }
 .detail-grid { display: grid; grid-template-columns: 1fr; gap: 1rem; margin-top: 1rem; }
 .detail-grid section { padding: 1rem; border: 1px solid var(--line); border-radius: 1rem; background: rgba(255,255,255,0.5); }
 .detail-grid--story section:first-child { background: color-mix(in srgb, var(--accent), #fff 91%); }
@@ -603,7 +604,8 @@ html[data-theme="dark"] .theme-toggle__thumb { transform: translateX(0.96rem); b
 .button { color: var(--button-text); }
 .button--ghost { color: var(--button-ghost-text); }
 .filters .is-active { color: var(--button-text); }
-.hero__lead, .project-card p, .timeline p, .lead, .project-detail__summary p, .project-detail__learned p { color: var(--copy); }
+.hero__lead, .lead, .project-detail__summary p { color: var(--copy); }
+.project-card p, .timeline p, .project-detail__learned p, .detail-grid p, .project-proof__intro { color: var(--copy-soft); }
 .project-empty { background: var(--chip-bg); color: var(--copy); }
 .hero__chips > span, .filters button, .skill-grid li { background: var(--tag-bg); color: var(--tag-text); border-color: var(--tag-border); }
 .hero__focus li, .detail-grid section, .project-proof article { background: color-mix(in srgb, var(--panel-strong), transparent 34%); }


### PR DESCRIPTION
### Motivation
- Retirer les traces internes visibles et clarifier des formulations publiques pour éviter d’afficher des TODO/commentaires non pertinents dans le site public.
- Ne pas présenter GitHub Actions comme une preuve opérationnelle quand son existence n’a pas pu être vérifiée depuis l’environnement de travail. 
- Rendre les modales de preuve plus lisibles et hiérarchisées pour faciliter la vérification technique par un lecteur.
- Améliorer la lisibilité des cards (tags visibles) et la cohérence couleurs thème clair/sombre via des tokens CSS.

### Description
- `src/data/portfolioData.ts` : suppression du commentaire `TODO` interne, clarification du projet `JLH AutoPam` (remplacement de la mention directe `GitHub Actions` par des formulations prudentes comme `préparation CI/CD` et retrait de `GitHub Actions` du tableau `stack`), réécriture de résumés/solutions/deliverables/impact pour différencier `JLH` (garage fullstack, PostgreSQL, JWT, Docker, déploiement reproductible) et `Locatech` (projet d’architecture Angular + Spring Boot, MySQL + MongoDB, Docker Compose, API catégories).
- `src/components/ProjectDetails.astro` : réorganisation de la section « Preuves techniques » pour afficher une phrase d’introduction conditionnelle (`project-proof__intro`) uniquement lorsque `hasProof` est vrai, renommage des blocs `Points clés` → `Preuves projet` et `Repères techniques` → `Stack vérifiable`, et conservation de `Compétences mobilisées`.
- `src/components/ProjectCard.astro` : ajout de `visibleStackCount` et logique `project.featured ? 6 : 5` puis usage de `project.stack.slice(0, visibleStackCount)` pour permettre jusqu’à 6 tags visibles sur les projets mis en avant.
- `src/components/ProjectVisual.astro` : ajustement du visuel Docker pour mieux distinguer Locatech (`Angular → API → MySQL → MongoDB`) et la pipeline JLH (reste orientée `Front/back → Images → Docker Hub → Hostinger`).
- `src/styles/global.css` : remplacement des couleurs fixes pertinentes par des tokens (`var(--copy)`, `var(--copy-soft)`, `--muted`, `--ink`) pour les sélecteurs ciblés et ajout de styles pour `.project-proof__intro` afin d’assurer contraste et cohérence thème clair/sombre.

### Testing
- Exécuté `npm ci --no-audit --no-fund` et l’installation a abouti sans erreur majeure.
- Build de production exécuté via `ASTRO_TELEMETRY_DISABLED=1 npm run build` et terminé avec succès (`3 page(s) built` et sortie `dist/`).
- Recherches automatiques `rg "TODO|FIXME" src` n’ont trouvé aucune occurrence restante dans `src`.
- Recherches `rg "GitHub Actions|CI/CD|Docker Hub|Hostinger|Java 17|Java 21" src` vérifiées et confirmées : la fiche JLH n’affiche plus `GitHub Actions` comme preuve active (les autres termes pertinents restent là où appropriés).
- Tentative automatisée de vérification du dépôt `steve57000/jlh` via l’API GitHub a renvoyé une erreur réseau (`CONNECT tunnel failed / 403`), donc la modification a suivi l’approche prudente demandée (ne pas présenter GitHub Actions comme déjà opérationnel).
- Vérification que les fichiers modifiés sont des fichiers textes (aucun binaire ajouté) et que `git diff --numstat` montre uniquement les fichiers sources modifiés; toutes les validations automatisées ont réussi.
