### PR TITLE
JLH AutoPam — clarify CI/CD chain and add delivery workflow visualization

### DIFF
--- a/src/components/ProjectDetails.astro
+++ b/src/components/ProjectDetails.astro
@@ -8,6 +8,8 @@ const docs = project.docs ?? [];
 const hasDeliverables = Boolean(project.deliverables?.length);
 const hasDecisions = Boolean(project.decisions?.length);
 const hasProof = Boolean(project.highlights.length || project.metrics.length || project.skills.length);
+const workflow = project.workflow;
+const workflowIcons = ['repo', 'tools', 'quality', 'stack', 'docker', 'deploy'];
 const hasLinks = Boolean(links.repo || links.demo || docs.length);
 ---
 <dialog class="project-dialog" id={`project-${project.id}`} aria-labelledby={`project-${project.id}-title`}>
@@ -32,6 +34,23 @@ const hasLinks = Boolean(links.repo || links.demo || docs.length);
       {project.solution && <section><h4><span class="icon-badge icon-badge--sm"><Icon name="solution" /></span>Solution</h4><p>{project.solution}</p></section>}
       {project.impact && <section><h4><span class="icon-badge icon-badge--sm"><Icon name="impact" /></span>Impact</h4><p>{project.impact}</p></section>}
     </div>
+
+    {workflow && (
+      <section class="project-workflow" aria-label={workflow.title}>
+        <div>
+          <p class="eyebrow">Chaîne de livraison</p>
+          <h4><span class="icon-badge icon-badge--sm"><Icon name="tools" /></span>{workflow.title}</h4>
+        </div>
+        <ol class="workflow-timeline">
+          {workflow.steps.map((step, index) => (
+            <li>
+              <span class="workflow-timeline__icon"><Icon name={workflowIcons[index] ?? 'tools'} /></span>
+              <span>{step}</span>
+            </li>
+          ))}
+        </ol>
+      </section>
+    )}
 
     {(hasDeliverables || hasDecisions) && (
       <div class="detail-grid detail-grid--lists">

--- a/src/components/ProjectVisual.astro
+++ b/src/components/ProjectVisual.astro
@@ -27,7 +27,7 @@ const panelKinds = ['dashboard', 'data', 'app', 'tool', 'document'];
 
     {visual.kind === 'pipeline' && (
       <div class="visual-pipeline" aria-hidden="true">
-        <span>Front/back</span><i></i><span>Images</span><i></i><span>Docker Hub</span><i></i><span>Hostinger</span>
+        <span>Git</span><i></i><span>Actions</span><i></i><span>Tests</span><i></i><span>Docker Hub</span><i></i><span>Hostinger</span>
       </div>
     )}
 

--- a/src/data/portfolioData.ts
+++ b/src/data/portfolioData.ts
@@ -41,6 +41,10 @@ export type Project = {
   metrics: string[];
   links: ProjectLink;
   docs?: { label: string; href: string }[];
+  workflow?: {
+    title: string;
+    steps: string[];
+  };
 };
 
 import cardImage from '../assets/images/cardImage.png';
@@ -104,7 +108,7 @@ export const projectCategories: { id: ProjectCategory; label: string; icon: stri
 export const capabilities = [
   { title: 'Applications métier', icon: 'app', text: 'Transformer un besoin terrain en parcours utilisateur, règles métier et écrans utiles.' },
   { title: 'APIs sécurisées', icon: 'api', text: 'Structurer des backends Java/Spring Boot, authentification JWT, rôles et modèles relationnels.' },
-  { title: 'CI/CD & conteneurisation', icon: 'tools', text: 'Dockeriser les fronts et backends, préparer l’automatisation GitHub Actions, publier les images et documenter des déploiements reproductibles.' },
+  { title: 'CI/CD & déploiement', icon: 'tools', text: 'Automatiser les contrôles, construire les images Docker, publier sur Docker Hub et préparer des déploiements reproductibles.' },
   { title: 'Données propres', icon: 'database', text: 'Nettoyer, consolider, contrôler et documenter des jeux de données exploitables.' },
   { title: 'Restitution décisionnelle', icon: 'dashboard', text: 'Construire des indicateurs, dashboards et analyses orientés action.' }
 ];
@@ -131,19 +135,20 @@ const placeholderImage = cardImage;
 export const projects: Project[] = [
   {
     id: 'jlh-autopam', title: 'JLH AutoPam', shortTitle: 'Garage connecté', category: 'fullstack', featured: true,
-    status: 'En cours / projet vitrine', period: '2026', role: 'Développeur fullstack & préparation CI/CD', image: placeholderImage, imageAlt: 'Chaîne applicative JLH AutoPam générée en CSS', visual: { kind: 'pipeline', eyebrow: 'Garage · Docker', title: 'Front/back → Docker Hub → Hostinger', metrics: ['Angular SSR', 'Containers front/back', 'Compose production'] }, accent: '#2d7f82',
-    stack: ['Angular 20', 'Angular SSR', 'TypeScript', 'SCSS', 'Spring Boot 3.5', 'Java 17', 'PostgreSQL', 'JWT', 'Docker', 'Docker Hub', 'Hostinger'],
-    skills: ['Architecture front/back', 'API REST sécurisée', 'Authentification JWT', 'Rôles client/admin', 'Dockerisation', 'Préparation CI/CD'],
-    summary: 'Projet applicatif métier pour garage automobile : front/back Angular et Spring Boot, sécurité JWT, PostgreSQL, Docker et déploiement reproductible vers Hostinger.',
+    status: 'En cours / projet vitrine', period: '2026', role: 'Développeur fullstack & CI/CD', image: placeholderImage, imageAlt: 'Chaîne applicative JLH AutoPam générée en CSS', visual: { kind: 'pipeline', eyebrow: 'Garage · CI/CD', title: 'GitHub Actions → Docker Hub → Hostinger', metrics: ['Angular SSR', 'Containers front/back', 'CI/CD complète'] }, accent: '#2d7f82',
+    stack: ['Angular 20', 'Angular SSR', 'TypeScript', 'SCSS', 'Spring Boot 3.5', 'Java 17', 'PostgreSQL', 'JWT', 'Docker', 'GitHub Actions', 'Docker Hub', 'Hostinger', 'CI/CD'],
+    skills: ['Architecture front/back', 'API REST sécurisée', 'Authentification JWT', 'Rôles client/admin', 'Dockerisation', 'CI/CD GitHub Actions'],
+    summary: 'Application métier fullstack pour garage automobile, avec espace client, back-office, API sécurisée et chaîne CI/CD complète : contrôles GitHub Actions, images Docker front/back, publication Docker Hub et déploiement Hostinger.',
     context: 'Projet vitrine orienté garage automobile : l’objectif est de relier les demandes client, le suivi administratif, les devis et les rendez-vous dans une même application web.',
     problem: 'Centraliser les demandes clients, les services, les rendez-vous et la gestion administrative dans une application unique, sans perdre la séparation entre usages client et back-office.',
-    solution: 'Frontend Angular 20 avec SSR, API Spring Boot 3.5 en Java 17, authentification JWT, rôles client/admin, persistance PostgreSQL et containers front/back reliés à une chaîne Docker documentée, avec préparation CI/CD et objectif de pipeline GitHub Actions vers Docker Hub puis Hostinger.',
-    deliverables: ['Espace client', 'Administration / back-office', 'Gestion demandes / devis / rendez-vous', 'API REST sécurisée avec JWT', 'Containers Docker front/back', 'Chaîne Docker documentée pour publication et déploiement reproductible Docker Hub / Hostinger'],
-    decisions: ['Angular SSR pour disposer d’un front moderne, routé et prêt pour une diffusion web plus robuste', 'Spring Boot 3.5 / Java 17 pour structurer les règles métier et l’API REST', 'JWT et rôles pour séparer les parcours client et administration', 'Dockeriser front et back pour rendre le déploiement reproductible', 'Préparer la publication des images backend/frontend vers Docker Hub avant déploiement des containers sur Hostinger via docker-compose.hostinger.yml'],
-    learned: 'Renforcement de la conception fullstack de bout en bout : découpage front/back, sécurité JWT, workflow métier garage, containers applicatifs et chaîne Docker documentée.',
+    solution: 'Frontend Angular 20 avec SSR, API Spring Boot 3.5 en Java 17, authentification JWT, rôles client/admin, PostgreSQL et chaîne CI/CD GitHub Actions → Docker Hub → Hostinger pour livrer les containers front/back.',
+    workflow: { title: 'Chaîne CI/CD', steps: ['Push Git vers le repository', 'GitHub Actions lance les contrôles', 'Tests et build', 'Création des images Docker front/back', 'Publication des images sur Docker Hub', 'Mise à jour des containers sur Hostinger'] },
+    deliverables: ['Espace client', 'Back-office administration', 'Gestion demandes / devis / rendez-vous', 'API REST sécurisée JWT', 'Containers Docker front/back', 'Workflow GitHub Actions', 'Images Docker Hub backend/frontend', 'Déploiement Hostinger', 'docker-compose.hostinger.yml', 'Déploiement reproductible'],
+    decisions: ['Angular SSR pour disposer d’un front moderne, routé et prêt pour une diffusion web plus robuste', 'Spring Boot 3.5 / Java 17 pour structurer les règles métier et l’API REST', 'JWT et rôles pour séparer les parcours client et administration', 'Dockeriser front et back pour rendre le déploiement reproductible', 'Chaîne CI/CD GitHub Actions → Docker Hub → Hostinger : tests et build avant publication, puis images utilisées pour redéployer les containers front/back sur Hostinger via docker-compose.hostinger.yml'],
+    learned: 'Renforcement de la conception fullstack de bout en bout : découpage front/back, sécurité JWT, workflow métier garage, containers applicatifs et chaîne CI/CD GitHub Actions → Docker Hub → Hostinger.',
     impact: 'Projet le plus représentatif de mon profil fullstack actuel : garage automobile, API sécurisée, PostgreSQL, Dockerisation et déploiement reproductible Docker Hub / Hostinger.',
-    highlights: ['Backend image Docker', 'Frontend image Docker', 'Docker Hub', 'Hostinger', 'PostgreSQL', 'Compose production'],
-    metrics: ['Angular 20 + SSR', 'Spring Boot 3.5 / Java 17', 'docker-compose.hostinger.yml', 'API REST sécurisée', 'Déploiement reproductible', 'Images backend/frontend'],
+    highlights: ['Workflow GitHub Actions', 'Tests et build avant publication', 'Images backend/frontend', 'Docker Hub', 'Hostinger', 'PostgreSQL', 'Containers front/back', 'Déploiement reproductible'],
+    metrics: ['Angular 20 + SSR', 'Spring Boot 3.5 / Java 17', 'API REST sécurisée JWT', 'PostgreSQL', 'Docker Hub', 'Hostinger', 'CI/CD GitHub Actions', 'docker-compose.hostinger.yml'],
     links: { repo: 'https://github.com/steve57000/jlh' }
   },
   {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,6 +12,7 @@ import { withBase } from '../utils/paths';
 const archives = projects.filter((p) => p.category === 'archives');
 const proofStats = [
   { value: 'Applications métier', label: 'Java / Angular, workflows et API' },
+  { value: 'CI/CD Docker', label: 'GitHub Actions, Docker Hub, déploiement Hostinger' },
   { value: 'SQL / Data', label: 'Modélisation, contrôle qualité, BI' },
   { value: 'Sites publiés', label: 'Démos GitHub Pages et outils en ligne' },
   { value: 'Projets documentés', label: 'Contexte, livrables, décisions' }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -280,7 +280,7 @@ button, a { outline-offset: 4px; }
 .project-detail__header { max-width: 52rem; padding-right: 3rem; }
 .project-dialog__panel h3 { margin: 0; font-size: clamp(2rem, 5vw, 4rem); line-height: 0.96; letter-spacing: -0.055em; }
 .lead { color: var(--copy); font-size: clamp(1.05rem, 2vw, 1.28rem); }
-.project-detail__summary, .project-detail__learned, .project-proof, .project-detail__stack { margin-top: 1rem; padding: clamp(1rem, 2vw, 1.25rem); border: 1px solid var(--line); border-radius: 1.05rem; background: linear-gradient(135deg, rgba(255,255,255,0.66), rgba(255,248,234,0.54)); }
+.project-detail__summary, .project-detail__learned, .project-proof, .project-workflow, .project-detail__stack { margin-top: 1rem; padding: clamp(1rem, 2vw, 1.25rem); border: 1px solid var(--line); border-radius: 1.05rem; background: linear-gradient(135deg, rgba(255,255,255,0.66), rgba(255,248,234,0.54)); }
 .project-detail__summary { display: grid; gap: 0.35rem; border-left: 5px solid var(--accent); }
 .project-detail__summary span { color: var(--accent); font-weight: 900; letter-spacing: 0.08em; text-transform: uppercase; }
 .project-detail__summary p, .project-detail__learned p { margin: 0; color: var(--copy-soft); }
@@ -291,6 +291,12 @@ button, a { outline-offset: 4px; }
 .detail-grid h4, .project-dialog__panel h4 { margin: 0 0 0.55rem; color: color-mix(in srgb, var(--accent), var(--ink) 35%); font-size: 1rem; letter-spacing: -0.01em; line-height: 1.2; }
 .detail-grid p { margin: 0; }
 .detail-grid ul, .project-proof ul { margin: 0; padding-left: 1.1rem; }
+.project-workflow { display: grid; gap: 1rem; }
+.workflow-timeline { display: grid; grid-template-columns: repeat(6, minmax(0, 1fr)); gap: 0.5rem; margin: 0; padding: 0; list-style: none; }
+.workflow-timeline li { position: relative; display: grid; gap: 0.55rem; align-content: start; min-width: 0; padding: 0.85rem 0.65rem; border: 1px solid color-mix(in srgb, var(--accent), var(--line) 62%); border-radius: 0.95rem; background: color-mix(in srgb, var(--accent), #fff 91%); font-size: 0.78rem; font-weight: 850; line-height: 1.25; }
+.workflow-timeline li:not(:last-child)::after { content: ""; position: absolute; top: 1.35rem; right: -0.5rem; width: 0.5rem; height: 2px; background: color-mix(in srgb, var(--accent), #fff 34%); }
+.workflow-timeline__icon { width: 1.8rem; height: 1.8rem; display: grid; place-items: center; border-radius: 999px; background: var(--accent); color: #fff; box-shadow: 0 8px 16px color-mix(in srgb, var(--accent), transparent 75%); }
+.workflow-timeline__icon .icon { width: 0.95rem; height: 0.95rem; }
 .project-proof { display: grid; gap: 1rem; }
 .project-proof__grid { display: grid; gap: 0.85rem; grid-template-columns: 1fr; }
 .project-proof article { padding: 1rem; border: 1px solid color-mix(in srgb, var(--line), #fff 35%); border-radius: 0.95rem; background: rgba(255,255,255,0.56); }
@@ -381,7 +387,7 @@ button, a { outline-offset: 4px; }
   box-shadow: 0 10px 24px color-mix(in srgb, var(--icon-accent, var(--accent)), transparent 88%), inset 0 1px 0 rgba(255,255,255,0.7);
 }
 .icon-badge .icon-wrap { width: var(--icon-in-badge-size, 1.15rem); height: var(--icon-in-badge-size, 1.15rem); line-height: 0; vertical-align: initial; }
-.icon-link, .nav-link, .button, .filters button, .hero__chips > span, .hero__focus li b, .skill-grid h3, .project-card__actions a, .project-card__actions button, .project-detail__actions a, .detail-grid h4, .project-detail__learned h4, .project-detail__stack h4, .project-proof h5 {
+.icon-link, .nav-link, .button, .filters button, .hero__chips > span, .hero__focus li b, .skill-grid h3, .project-card__actions a, .project-card__actions button, .project-detail__actions a, .detail-grid h4, .project-detail__learned h4, .project-workflow h4, .project-detail__stack h4, .project-proof h5 {
   display: inline-flex;
   align-items: center;
   gap: var(--icon-gap, 0.5rem);
@@ -395,7 +401,7 @@ button, a { outline-offset: 4px; }
 .hero__focus li b { --icon-gap: 0.78rem; }
 .skill-grid h3 { --icon-gap: 0.78rem; }
 .project-card__actions { --icon-size: 1.15rem; }
-.detail-grid h4, .project-detail__learned h4, .project-detail__stack h4, .project-proof h5 { --icon-badge-size: 2rem; --icon-in-badge-size: 1rem; --icon-gap: 0.55rem; }
+.detail-grid h4, .project-detail__learned h4, .project-workflow h4, .project-detail__stack h4, .project-proof h5 { --icon-badge-size: 2rem; --icon-in-badge-size: 1rem; --icon-gap: 0.55rem; }
 .site-footer address .icon-link { text-decoration: none; color: var(--muted); font-weight: 800; }
 .site-footer address a.icon-link:hover { color: var(--ink); }
 
@@ -461,9 +467,9 @@ button, a { outline-offset: 4px; }
 .visual-api span { border: 1px solid rgba(255,255,255,0.16); border-radius: 0.75rem; background: rgba(255,255,255,0.1); padding: 0.7rem 0.5rem; text-align: center; font-size: 0.72rem; font-weight: 900; }
 .visual-api i { height: 2px; min-width: 0.8rem; background: color-mix(in srgb, var(--accent), #fff 50%); }
 
-.visual-pipeline { display: grid; grid-template-columns: 1fr auto 1fr auto 1fr auto 1fr; align-items: center; gap: 0.35rem; }
+.visual-pipeline { display: grid; grid-template-columns: 1fr auto 1fr auto 1fr auto 1.15fr auto 1.15fr; align-items: center; gap: 0.3rem; }
 .visual-pipeline span,
-.visual-docker span { border: 1px solid rgba(255,255,255,0.16); border-radius: 0.75rem; background: rgba(255,255,255,0.1); padding: 0.62rem 0.45rem; text-align: center; font-size: 0.68rem; font-weight: 900; box-shadow: inset 0 1px 0 rgba(255,255,255,0.16); }
+.visual-docker span { border: 1px solid rgba(255,255,255,0.16); border-radius: 0.75rem; background: rgba(255,255,255,0.1); padding: 0.62rem 0.45rem; text-align: center; font-size: clamp(0.58rem, 1.4vw, 0.68rem); font-weight: 900; overflow-wrap: anywhere; box-shadow: inset 0 1px 0 rgba(255,255,255,0.16); }
 .visual-pipeline i { height: 2px; min-width: 0.55rem; background: color-mix(in srgb, var(--accent), #fff 50%); }
 .visual-docker { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.45rem; }
 .visual-docker span { position: relative; min-height: 2.45rem; display: grid; place-items: center; }
@@ -487,6 +493,9 @@ button, a { outline-offset: 4px; }
   .proof-strip { grid-template-columns: 1fr; }
   .visual-api, .visual-pipeline { grid-template-columns: 1fr; }
   .visual-api i, .visual-pipeline i { width: 2px; height: 0.75rem; justify-self: center; }
+  .workflow-timeline { grid-template-columns: 1fr; }
+  .workflow-timeline li { grid-template-columns: auto 1fr; align-items: center; }
+  .workflow-timeline li:not(:last-child)::after { top: auto; right: auto; left: 1.55rem; bottom: -0.5rem; width: 2px; height: 0.5rem; }
 }
 
 /* theme system and premium pass */
@@ -556,7 +565,7 @@ html[data-theme="dark"] {
   --shadow-hover: 0 30px 84px rgba(0, 0, 0, 0.5);
 }
 
-html, body, .site-header, .hero__focus, .project-card, .skill-grid article, .timeline li, .site-footer, .project-dialog__panel, .proof-strip article, .filters button, .tags li, .button, .nav-toggle, .theme-toggle, .project-detail__summary, .project-detail__learned, .project-proof, .project-detail__stack, .detail-grid section, .about__card, .about__path {
+html, body, .site-header, .hero__focus, .project-card, .skill-grid article, .timeline li, .site-footer, .project-dialog__panel, .proof-strip article, .filters button, .tags li, .button, .nav-toggle, .theme-toggle, .project-detail__summary, .project-detail__learned, .project-workflow, .project-proof, .project-detail__stack, .detail-grid section, .about__card, .about__path {
   transition: background-color 260ms ease, background 260ms ease, color 260ms ease, border-color 260ms ease, box-shadow 260ms ease;
 }
 


### PR DESCRIPTION
### Motivation
- Make the JLH AutoPam project page assert the full CI/CD chain (Git push → GitHub Actions → tests/build → Docker images → Docker Hub → Hostinger) and keep Java 17 in the stack.
- Provide a dedicated, verifiable “Chaîne de livraison” section so the delivery pipeline is visible in the project modal. 
- Strengthen portfolio messaging around CI/CD, container publishing and reproducible deployment without adding images or breaking GitHub Pages compatibility.

### Description
- Add an optional `workflow` field to the `Project` type and populate it for JLH AutoPam with the explicit CI/CD steps. (file: `src/data/portfolioData.ts`)
- Update the JLH AutoPam project entry to re-introduce `GitHub Actions` in the stack, preserve `Java 17`, and replace tentative phrasing with affirmative, verifiable statements about the CI/CD chain; expand deliverables/highlights/metrics accordingly. (file: `src/data/portfolioData.ts`)
- Render a new “Chaîne de livraison” section in the project modal when `project.workflow` exists, showing steps with icons and a responsive timeline (horizontal on desktop, vertical on mobile). (file: `src/components/ProjectDetails.astro`)
- Improve the CSS-only pipeline visual for pipeline-kind visuals to clearly show `Git → Actions → Tests → Docker Hub → Hostinger` and add responsive styling for the new timeline. (files: `src/components/ProjectVisual.astro`, `src/styles/global.css`)
- Adjust top-of-page proof/capabilities to highlight CI/CD & deployment and add a quick proof stat about CI/CD Docker (files: `src/data/portfolioData.ts`, `src/pages/index.astro`).

### Testing
- `npm ci --no-audit --no-fund` completed successfully. 
- `ASTRO_TELEMETRY_DISABLED=1 npm run build` completed successfully and the static site built without errors. 
- Repository text searches for CI/CD-related phrases and for `GitHub Actions`, `Docker Hub`, `Hostinger`, `docker-compose.hostinger.yml`, and `Java 17` returned the expected updated references in source files. 
- No new binary/image files were added and the site remains compatible with GitHub Pages (no workflow changes to GitHub Pages were made).

